### PR TITLE
chore(fmt): fix '*.go' files formatting by 'go fmt'

### DIFF
--- a/cmd/jsonschema-validator/main.go
+++ b/cmd/jsonschema-validator/main.go
@@ -30,16 +30,16 @@ func main() {
 func run() error {
 	// Define flags
 	var (
-		showVersion      bool
-		showHelp         bool
-		configFile       string
-		schemaPath       string
-		schemaVersion    string
-		errorTemplate    string
-		refOverrides     []string
-		documents        []string
-		envPrefix        string
-		forceFiletype    string
+		showVersion   bool
+		showHelp      bool
+		configFile    string
+		schemaPath    string
+		schemaVersion string
+		errorTemplate string
+		refOverrides  []string
+		documents     []string
+		envPrefix     string
+		forceFiletype string
 	)
 
 	pflag.BoolVarP(&showVersion, "version", "v", false, "Show version and exit")
@@ -112,7 +112,7 @@ For more information, see: https://github.com/iilei/terraform-provider-jsonschem
 
 	// Load configuration
 	loader := config.NewLoader()
-	
+
 	// Set custom environment prefix if provided
 	if envPrefix != "" {
 		// Ensure prefix ends with underscore
@@ -121,11 +121,11 @@ For more information, see: https://github.com/iilei/terraform-provider-jsonschem
 		}
 		loader.SetEnvPrefix(envPrefix)
 	}
-	
+
 	// Load from specific config file if provided
 	var cfg *config.Config
 	var err error
-	
+
 	if configFile != "" {
 		cfg, err = loader.LoadFromFile(configFile)
 		if err != nil {
@@ -274,13 +274,13 @@ func validateSchema(schemaConfig config.SchemaConfig, globalConfig *config.Confi
 func validateDocument(docPath string, schema *jsonschema.Schema, schemaConfig config.SchemaConfig, globalConfig *config.Config, flagForceFiletype string) error {
 	// Get effective force_filetype: command-line flag > config file > auto-detect
 	effectiveForceFiletype := schemaConfig.GetEffectiveForceFiletype(flagForceFiletype)
-	
+
 	// Parse document file with optional forced file type
 	fileType := validator.FileType(effectiveForceFiletype)
 	if fileType == "" {
 		fileType = validator.FileTypeAuto
 	}
-	
+
 	docData, err := validator.ParseFile(docPath, fileType)
 	if err != nil {
 		return fmt.Errorf("failed to parse document %q: %w", docPath, err)

--- a/internal/provider/config.go
+++ b/internal/provider/config.go
@@ -10,13 +10,13 @@ import (
 type ProviderConfig struct {
 	// DefaultSchemaVersion specifies the JSON Schema version to use when not specified in the schema
 	DefaultSchemaVersion string
-	
+
 	// DefaultErrorTemplate is the default error message template
 	DefaultErrorTemplate string
-	
+
 	// DetailedErrors enables detailed structured error output
 	DetailedErrors bool
-	
+
 	// DefaultDraft is the default draft to use
 	DefaultDraft *jsonschema.Draft
 }
@@ -27,14 +27,14 @@ func NewProviderConfig(schemaVersion, errorTemplate string, detailedErrors bool)
 	if errorTemplate == "" {
 		errorTemplate = "{{.FullMessage}}"
 	}
-	
+
 	config := &ProviderConfig{
 		DefaultSchemaVersion: schemaVersion,
 		DefaultErrorTemplate: errorTemplate,
 		DetailedErrors:       detailedErrors,
 		DefaultDraft:         jsonschema.Draft2020, // Default to latest draft
 	}
-	
+
 	// Set draft based on schema version if provided
 	if schemaVersion != "" {
 		draft, err := GetDraftForVersion(schemaVersion)
@@ -43,7 +43,7 @@ func NewProviderConfig(schemaVersion, errorTemplate string, detailedErrors bool)
 		}
 		config.DefaultDraft = draft
 	}
-	
+
 	return config, nil
 }
 

--- a/internal/provider/config_test.go
+++ b/internal/provider/config_test.go
@@ -7,8 +7,8 @@ import (
 
 func TestNewProviderConfig(t *testing.T) {
 	tests := []struct {
-		name           string
-		schemaVersion  string
+		name          string
+		schemaVersion string
 		errorTemplate string
 		expectError   bool
 		errorContains string
@@ -107,7 +107,7 @@ func TestGetDraftForVersion(t *testing.T) {
 		{"draft/2019-09", false},
 		{"draft/2020-12", false},
 		{"invalid", true},
-		{"", true}, // empty should be invalid
+		{"", true},         // empty should be invalid
 		{"draft-05", true}, // non-existent version
 	}
 
@@ -171,7 +171,7 @@ func TestGetDraftForVersionURLFormats(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
 			draft, err := GetDraftForVersion(tt.version)
-			
+
 			if tt.expectError {
 				if err == nil {
 					t.Errorf("expected error for %s, but got none", tt.description)

--- a/internal/provider/coverage_improvement_test.go
+++ b/internal/provider/coverage_improvement_test.go
@@ -1,8 +1,8 @@
 package provider
 
 import (
-validator "github.com/iilei/terraform-provider-jsonschema/pkg/jsonschema"
 	"encoding/json"
+	validator "github.com/iilei/terraform-provider-jsonschema/pkg/jsonschema"
 	"os"
 	"path/filepath"
 	"strings"
@@ -16,45 +16,45 @@ validator "github.com/iilei/terraform-provider-jsonschema/pkg/jsonschema"
 func TestGenerateSortedFullMessage_EmptyErrors(t *testing.T) {
 	// Create a ValidationError with no causes (empty error tree)
 	// This is a theoretical edge case where the error exists but has no extractable details
-	
+
 	// We need to create a schema that will compile and then manually construct
 	// a validation scenario that might not have detailed errors
-	
+
 	schemaJSON := `{
 		"$schema": "https://json-schema.org/draft/2020-12/schema",
 		"type": "object"
 	}`
-	
+
 	var schemaData interface{}
 	if err := json.Unmarshal([]byte(schemaJSON), &schemaData); err != nil {
 		t.Fatalf("Failed to parse schema: %v", err)
 	}
-	
+
 	compiler := jsonschema.NewCompiler()
 	compiler.DefaultDraft(jsonschema.Draft2020)
-	
+
 	if err := compiler.AddResource("test://schema", schemaData); err != nil {
 		t.Fatalf("Failed to add schema: %v", err)
 	}
-	
+
 	compiledSchema, err := compiler.Compile("test://schema")
 	if err != nil {
 		t.Fatalf("Failed to compile schema: %v", err)
 	}
-	
+
 	// Try to validate something that will fail at a fundamental level
 	// Using a non-object type when object is required
 	err = compiledSchema.Validate("not an object")
 	if err == nil {
 		t.Fatal("Expected validation to fail")
 	}
-	
+
 	// Check if we can format this error
 	result := validator.FormatValidationError(err, "test.json", `"not an object"`, "{{.FullMessage}}")
 	if result == nil {
 		t.Fatal("Expected error result")
 	}
-	
+
 	// The message should still contain the schema URL even if no detailed errors
 	errMsg := result.Error()
 	if !strings.Contains(errMsg, "test://schema") || !strings.Contains(errMsg, "validation") {
@@ -67,7 +67,7 @@ func TestDataSourceJsonschemaValidatorRead_NoDraftConfiguration(t *testing.T) {
 	// Create a temporary schema file without $schema field
 	tempDir := t.TempDir()
 	schemaPath := filepath.Join(tempDir, "test.schema.json")
-	
+
 	schemaContent := `{
 		"type": "object",
 		"properties": {
@@ -75,7 +75,7 @@ func TestDataSourceJsonschemaValidatorRead_NoDraftConfiguration(t *testing.T) {
 		},
 		"required": ["name"]
 	}`
-	
+
 	if err := os.WriteFile(schemaPath, []byte(schemaContent), 0644); err != nil {
 		t.Fatalf("Failed to create schema file: %v", err)
 	}
@@ -85,34 +85,34 @@ func TestDataSourceJsonschemaValidatorRead_NoDraftConfiguration(t *testing.T) {
 	if err := os.WriteFile(docPath, []byte(`{"name": "test"}`), 0644); err != nil {
 		t.Fatalf("Failed to create document file: %v", err)
 	}
-	
+
 	// Create resource data
 	d := schema.TestResourceDataRaw(t, map[string]*schema.Schema{
-		"document": {Type: schema.TypeString},
-		"schema":   {Type: schema.TypeString},
-		"schema_version": {Type: schema.TypeString},
+		"document":               {Type: schema.TypeString},
+		"schema":                 {Type: schema.TypeString},
+		"schema_version":         {Type: schema.TypeString},
 		"error_message_template": {Type: schema.TypeString},
-		"ref_overrides": {Type: schema.TypeMap},
-		"valid_json": {Type: schema.TypeString},
+		"ref_overrides":          {Type: schema.TypeMap},
+		"valid_json":             {Type: schema.TypeString},
 	}, map[string]interface{}{
-		"document": docPath,
-		"schema":   schemaPath,
+		"document":       docPath,
+		"schema":         schemaPath,
 		"schema_version": "", // No version specified
 	})
-	
+
 	// Create provider config with NO default schema version and NO default draft
 	config := &ProviderConfig{
-		DefaultSchemaVersion: "", // Empty - no default
+		DefaultSchemaVersion: "",  // Empty - no default
 		DefaultDraft:         nil, // Nil - no default draft
 		DefaultErrorTemplate: "",
 	}
-	
+
 	// This should trigger the fallback to Draft2020 (line 121)
 	err := dataSourceJsonschemaValidatorRead(d, config)
 	if err != nil {
 		t.Fatalf("Expected validation to succeed with Draft2020 fallback: %v", err)
 	}
-	
+
 	// Verify the document was validated successfully
 	validJson := d.Get("valid_json").(string)
 	if validJson == "" {
@@ -129,7 +129,7 @@ func TestDataSourceJsonschemaValidatorRead_DuplicateSchemaURL(t *testing.T) {
 	// Create a temporary schema file
 	tempDir := t.TempDir()
 	schemaPath := filepath.Join(tempDir, "test.schema.json")
-	
+
 	schemaContent := `{
 		"$schema": "https://json-schema.org/draft/2020-12/schema",
 		"type": "object",
@@ -137,7 +137,7 @@ func TestDataSourceJsonschemaValidatorRead_DuplicateSchemaURL(t *testing.T) {
 			"name": {"type": "string"}
 		}
 	}`
-	
+
 	if err := os.WriteFile(schemaPath, []byte(schemaContent), 0644); err != nil {
 		t.Fatalf("Failed to create schema file: %v", err)
 	}
@@ -147,35 +147,35 @@ func TestDataSourceJsonschemaValidatorRead_DuplicateSchemaURL(t *testing.T) {
 	if err := os.WriteFile(docPath, []byte(`{"name": "test"}`), 0644); err != nil {
 		t.Fatalf("Failed to create document file: %v", err)
 	}
-	
+
 	// Create resource data
 	d := schema.TestResourceDataRaw(t, map[string]*schema.Schema{
-		"document": {Type: schema.TypeString},
-		"schema":   {Type: schema.TypeString},
-		"schema_version": {Type: schema.TypeString},
+		"document":               {Type: schema.TypeString},
+		"schema":                 {Type: schema.TypeString},
+		"schema_version":         {Type: schema.TypeString},
 		"error_message_template": {Type: schema.TypeString},
-		"ref_overrides": {Type: schema.TypeMap},
-		"valid_json": {Type: schema.TypeString},
+		"ref_overrides":          {Type: schema.TypeMap},
+		"valid_json":             {Type: schema.TypeString},
 	}, map[string]interface{}{
 		"document": docPath,
 		"schema":   schemaPath,
 	})
-	
+
 	config := &ProviderConfig{
 		DefaultSchemaVersion: "draft/2020-12",
 		DefaultErrorTemplate: "",
 	}
-	
+
 	// First call should succeed
 	err := dataSourceJsonschemaValidatorRead(d, config)
 	if err != nil {
 		t.Fatalf("First validation failed: %v", err)
 	}
-	
+
 	// Note: We can't easily trigger the AddResource error in lines 158-159
 	// because each call to dataSourceJsonschemaValidatorRead creates a new compiler
 	// instance, so there's no way to get duplicate registrations.
-	// 
+	//
 	// The AddResource error path at lines 158-159 is defensive programming
 	// for scenarios that are extremely unlikely to occur in practice without
 	// significant changes to the code structure (e.g., reusing compiler instances).

--- a/internal/provider/data_source_jsonschema_validator.go
+++ b/internal/provider/data_source_jsonschema_validator.go
@@ -12,8 +12,6 @@ import (
 	"github.com/santhosh-tekuri/jsonschema/v6"
 )
 
-
-
 func dataSourceJsonschemaValidator() *schema.Resource {
 	return &schema.Resource{
 		Read: dataSourceJsonschemaValidatorRead,
@@ -71,7 +69,7 @@ func dataSourceJsonschemaValidatorRead(d *schema.ResourceData, m interface{}) er
 	schemaPath := d.Get("schema").(string)
 	schemaVersionOverride := d.Get("schema_version").(string)
 	errorMessageTemplate := d.Get("error_message_template").(string)
-	
+
 	// Use provider default if no template specified
 	if errorMessageTemplate == "" {
 		errorMessageTemplate = config.DefaultErrorTemplate
@@ -82,7 +80,7 @@ func dataSourceJsonschemaValidatorRead(d *schema.ResourceData, m interface{}) er
 	if docFileType == "" {
 		docFileType = validator.FileTypeAuto
 	}
-	
+
 	documentData, err := validator.ParseFile(documentPath, docFileType)
 	if err != nil {
 		return fmt.Errorf("failed to parse document file %q: %w", documentPath, err)
@@ -96,12 +94,12 @@ func dataSourceJsonschemaValidatorRead(d *schema.ResourceData, m interface{}) er
 
 	// Create a new compiler instance for this validation
 	compiler := jsonschema.NewCompiler()
-	
+
 	// Enable JSON5 support for $ref loading
 	compiler.UseLoader(jsonschema.SchemeURLLoader{
 		"file": validator.JSON5FileLoader{},
 	})
-	
+
 	// Determine which schema version to use
 	effectiveSchemaVersion := config.DefaultSchemaVersion
 	if schemaVersionOverride != "" {
@@ -139,22 +137,22 @@ func dataSourceJsonschemaValidatorRead(d *schema.ResourceData, m interface{}) er
 	// - Air-gapped environments (no internet access required)
 	if refOverridesRaw, ok := d.GetOk("ref_overrides"); ok {
 		refOverrides := refOverridesRaw.(map[string]interface{})
-		
+
 		for remoteURL, localPathRaw := range refOverrides {
 			localPath := localPathRaw.(string)
-			
+
 			// Parse the override schema file (supports JSON, JSON5, YAML, TOML - auto-detect)
 			overrideData, err := validator.ParseFile(localPath, validator.FileTypeAuto)
 			if err != nil {
-				return fmt.Errorf("ref_override: failed to parse local file %q for URL %q: %w", 
+				return fmt.Errorf("ref_override: failed to parse local file %q for URL %q: %w",
 					localPath, remoteURL, err)
 			}
-			
+
 			// Pre-register this schema at the remote URL.
 			// When the compiler encounters "$ref": "remoteURL" during schema compilation,
 			// it will use this pre-registered data instead of attempting to load from the URL.
 			if err := compiler.AddResource(remoteURL, overrideData); err != nil {
-				return fmt.Errorf("ref_override: failed to register %q -> %q: %w", 
+				return fmt.Errorf("ref_override: failed to register %q -> %q: %w",
 					remoteURL, localPath, err)
 			}
 		}
@@ -179,11 +177,11 @@ func dataSourceJsonschemaValidatorRead(d *schema.ResourceData, m interface{}) er
 	if err := json.Unmarshal([]byte(schemaJSON), &parsedSchemaData); err != nil {
 		return fmt.Errorf("failed to parse schema JSON: %w", err)
 	}
-	
+
 	if err := compiler.AddResource(schemaURL, parsedSchemaData); err != nil {
 		return fmt.Errorf("failed to add schema resource: %w", err)
 	}
-	
+
 	compiledSchema, err := compiler.Compile(schemaURL)
 	if err != nil {
 		return fmt.Errorf("failed to compile schema: %w", err)
@@ -207,10 +205,10 @@ func dataSourceJsonschemaValidatorRead(d *schema.ResourceData, m interface{}) er
 
 	// Generate ID based on document, schema, and configuration
 	// schemaJSON is already available from earlier in the function
-	
-	compositeString := fmt.Sprintf("%s:%s:%s", 
-		string(canonicalJSON), 
-		string(schemaJSON), 
+
+	compositeString := fmt.Sprintf("%s:%s:%s",
+		string(canonicalJSON),
+		string(schemaJSON),
 		effectiveSchemaVersion,
 	)
 	d.SetId(hash(compositeString))

--- a/internal/provider/data_source_jsonschema_validator_test.go
+++ b/internal/provider/data_source_jsonschema_validator_test.go
@@ -31,50 +31,50 @@ func Test_dataSourceJsonschemaValidatorRead(t *testing.T) {
 	}
 
 	var cases = []struct {
-		name          string
-		documentContent string
+		name             string
+		documentContent  string
 		documentFileName string
-		schemaFile    string
-		errorExpected bool
-		expectedJSON  string
+		schemaFile       string
+		errorExpected    bool
+		expectedJSON     string
 	}{
 		{
-			name:          "invalid document",
-			documentContent: "asd asdasd: ^%^*&^%",
+			name:             "invalid document",
+			documentContent:  "asd asdasd: ^%^*&^%",
 			documentFileName: "invalid.txt",
-			schemaFile:    schemaFile,
-			errorExpected: true,
+			schemaFile:       schemaFile,
+			errorExpected:    true,
 		},
 		{
-			name:          "empty object fails required validation",
-			documentContent: "{}",
+			name:             "empty object fails required validation",
+			documentContent:  "{}",
 			documentFileName: "empty.json",
-			schemaFile:    schemaFile,
-			errorExpected: true,
+			schemaFile:       schemaFile,
+			errorExpected:    true,
 		},
 		{
-			name:          "valid document",
-			documentContent: `{"test": "test"}`,
+			name:             "valid document",
+			documentContent:  `{"test": "test"}`,
 			documentFileName: "valid.json",
-			schemaFile:    schemaFile,
-			errorExpected: false,
-			expectedJSON:  `{"test":"test"}`,
+			schemaFile:       schemaFile,
+			errorExpected:    false,
+			expectedJSON:     `{"test":"test"}`,
 		},
 		{
-			name:          "JSON5 document with comments",
-			documentContent: `{"test": "test", /* comment */ }`,
+			name:             "JSON5 document with comments",
+			documentContent:  `{"test": "test", /* comment */ }`,
 			documentFileName: "valid.json5",
-			schemaFile:    schemaFile,
-			errorExpected: false,
-			expectedJSON:  `{"test":"test"}`,
+			schemaFile:       schemaFile,
+			errorExpected:    false,
+			expectedJSON:     `{"test":"test"}`,
 		},
 		{
-			name:          "JSON5 schema with JSON document",
-			documentContent: `{"name": "example", "age": 25}`,
+			name:             "JSON5 schema with JSON document",
+			documentContent:  `{"name": "example", "age": 25}`,
 			documentFileName: "person.json",
-			schemaFile:    json5SchemaFile,
-			errorExpected: false,
-			expectedJSON:  `{"age":25,"name":"example"}`,
+			schemaFile:       json5SchemaFile,
+			errorExpected:    false,
+			expectedJSON:     `{"age":25,"name":"example"}`,
 		},
 	}
 
@@ -171,42 +171,42 @@ func TestMultipleSchemasInSameDirectory(t *testing.T) {
 	}
 
 	var cases = []struct {
-		name          string
-		documentContent string
+		name             string
+		documentContent  string
 		documentFileName string
-		schemaFile    string
-		errorExpected bool
-		expectedJSON  string
+		schemaFile       string
+		errorExpected    bool
+		expectedJSON     string
 	}{
 		{
-			name:          "validate user document",
-			documentContent: `{"name": "John", "email": "john@example.com"}`,
+			name:             "validate user document",
+			documentContent:  `{"name": "John", "email": "john@example.com"}`,
 			documentFileName: "user.json",
-			schemaFile:    schema1File,
-			errorExpected: false,
-			expectedJSON:  `{"email":"john@example.com","name":"John"}`,
+			schemaFile:       schema1File,
+			errorExpected:    false,
+			expectedJSON:     `{"email":"john@example.com","name":"John"}`,
 		},
 		{
-			name:          "validate product document",
-			documentContent: `{"sku": "ABC123", "price": 99.99}`,
+			name:             "validate product document",
+			documentContent:  `{"sku": "ABC123", "price": 99.99}`,
 			documentFileName: "product.json",
-			schemaFile:    schema2File,
-			errorExpected: false,
-			expectedJSON:  `{"price":99.99,"sku":"ABC123"}`,
+			schemaFile:       schema2File,
+			errorExpected:    false,
+			expectedJSON:     `{"price":99.99,"sku":"ABC123"}`,
 		},
 		{
-			name:          "invalid user document against user schema",
-			documentContent: `{"name": "John"}`, // missing email
+			name:             "invalid user document against user schema",
+			documentContent:  `{"name": "John"}`, // missing email
 			documentFileName: "invalid_user.json",
-			schemaFile:    schema1File,
-			errorExpected: true,
+			schemaFile:       schema1File,
+			errorExpected:    true,
 		},
 		{
-			name:          "invalid product document against product schema",
-			documentContent: `{"sku": "ABC123"}`, // missing price
+			name:             "invalid product document against product schema",
+			documentContent:  `{"sku": "ABC123"}`, // missing price
 			documentFileName: "invalid_product.json",
-			schemaFile:    schema2File,
-			errorExpected: true,
+			schemaFile:       schema2File,
+			errorExpected:    true,
 		},
 	}
 
@@ -545,4 +545,3 @@ func TestRefOverridesErrors(t *testing.T) {
 		}
 	})
 }
-

--- a/internal/provider/data_source_unit_test.go
+++ b/internal/provider/data_source_unit_test.go
@@ -58,16 +58,16 @@ func TestDataSourceJsonschemaValidatorRead(t *testing.T) {
 	}
 
 	tests := []struct {
-		name                   string
-		documentContent        string
-		documentFileName       string
-		schemaFile             string
-		schemaVersionOverride  string
-		errorMessageTemplate   string
-		providerConfig         *ProviderConfig
-		expectError            bool
-		errorContains          string
-		expectedValidJson      string
+		name                  string
+		documentContent       string
+		documentFileName      string
+		schemaFile            string
+		schemaVersionOverride string
+		errorMessageTemplate  string
+		providerConfig        *ProviderConfig
+		expectError           bool
+		errorContains         string
+		expectedValidJson     string
 	}{
 		{
 			name:             "valid document validation",
@@ -233,11 +233,11 @@ func TestDataSourceJsonschemaValidatorRead_InvalidProviderConfig(t *testing.T) {
 
 	// Pass invalid config type
 	err = dataSourceJsonschemaValidatorRead(resourceData, "invalid-config")
-	
+
 	if err == nil {
 		t.Errorf("expected error for invalid provider config")
 	}
-	
+
 	if !strings.Contains(err.Error(), "invalid provider configuration") {
 		t.Errorf("expected specific error message, got: %v", err)
 	}
@@ -273,7 +273,7 @@ func TestDataSourceJsonschemaValidatorRead_InvalidDocumentParsing(t *testing.T) 
 	}
 
 	err = dataSourceJsonschemaValidatorRead(resourceData, config)
-	
+
 	if err == nil || !strings.Contains(err.Error(), "failed to parse document") {
 		t.Errorf("expected 'failed to parse document' error, got: %v", err)
 	}
@@ -310,11 +310,11 @@ func TestDataSourceJsonschemaValidatorRead_InvalidSchemaVersion(t *testing.T) {
 	}
 
 	err = dataSourceJsonschemaValidatorRead(resourceData, config)
-	
+
 	if err == nil {
 		t.Errorf("expected error for invalid schema version")
 	}
-	
+
 	if !strings.Contains(err.Error(), "unsupported JSON Schema version") {
 		t.Errorf("expected specific error message, got: %v", err)
 	}
@@ -343,7 +343,7 @@ func TestDataSourceJsonschemaValidatorRead_MissingSchemaFile(t *testing.T) {
 	}
 
 	err = dataSourceJsonschemaValidatorRead(resourceData, config)
-	
+
 	if err == nil || !strings.Contains(err.Error(), "failed to parse schema file") {
 		t.Errorf("expected 'failed to parse schema file' error, got: %v", err)
 	}
@@ -378,7 +378,7 @@ func TestDataSourceJsonschemaValidatorRead_UnreadableSchemaFile(t *testing.T) {
 	}
 
 	err = dataSourceJsonschemaValidatorRead(resourceData, config)
-	
+
 	if err == nil || !strings.Contains(err.Error(), "failed to parse schema file") {
 		t.Errorf("expected 'failed to parse schema file' error, got: %v", err)
 	}
@@ -413,7 +413,7 @@ func TestDataSourceJsonschemaValidatorRead_InvalidSchemaFile(t *testing.T) {
 	}
 
 	err = dataSourceJsonschemaValidatorRead(resourceData, config)
-	
+
 	if err == nil || !strings.Contains(err.Error(), "failed to parse schema file") {
 		t.Errorf("expected 'failed to parse schema file' error, got: %v", err)
 	}
@@ -592,14 +592,14 @@ func TestDataSourceJsonschemaValidatorRead_RefOverrides(t *testing.T) {
 	}
 
 	tests := []struct {
-		name          string
+		name            string
 		documentContent string
-		refOverrides  map[string]interface{}
-		expectError   bool
-		errorContains string
+		refOverrides    map[string]interface{}
+		expectError     bool
+		errorContains   string
 	}{
 		{
-			name:     "valid ref override",
+			name:            "valid ref override",
 			documentContent: `{"user": {"name": "John", "email": "john@example.com"}}`,
 			refOverrides: map[string]interface{}{
 				"https://example.com/schemas/user.json": overrideSchemaFile,
@@ -607,7 +607,7 @@ func TestDataSourceJsonschemaValidatorRead_RefOverrides(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name:     "validation fails with override",
+			name:            "validation fails with override",
 			documentContent: `{"user": {"email": "john@example.com"}}`, // missing required "name"
 			refOverrides: map[string]interface{}{
 				"https://example.com/schemas/user.json": overrideSchemaFile,
@@ -616,7 +616,7 @@ func TestDataSourceJsonschemaValidatorRead_RefOverrides(t *testing.T) {
 			errorContains: "validation",
 		},
 		{
-			name:     "missing override file",
+			name:            "missing override file",
 			documentContent: `{"user": {"name": "John"}}`,
 			refOverrides: map[string]interface{}{
 				"https://example.com/schemas/user.json": "/nonexistent/file.json",
@@ -625,7 +625,7 @@ func TestDataSourceJsonschemaValidatorRead_RefOverrides(t *testing.T) {
 			errorContains: "ref_override: failed to parse local file",
 		},
 		{
-			name:     "invalid override file syntax",
+			name:            "invalid override file syntax",
 			documentContent: `{"user": {"name": "John"}}`,
 			refOverrides: map[string]interface{}{
 				"https://example.com/schemas/user.json": invalidOverrideFile,
@@ -634,7 +634,7 @@ func TestDataSourceJsonschemaValidatorRead_RefOverrides(t *testing.T) {
 			errorContains: "ref_override: failed to parse local file",
 		},
 		{
-			name:     "unreadable override file",
+			name:            "unreadable override file",
 			documentContent: `{"user": {"name": "John"}}`,
 			refOverrides: map[string]interface{}{
 				"https://example.com/schemas/user.json": unreadableOverrideFile,
@@ -643,7 +643,7 @@ func TestDataSourceJsonschemaValidatorRead_RefOverrides(t *testing.T) {
 			errorContains: "ref_override: failed to parse local file",
 		},
 		{
-			name:     "invalid schema structure in override",
+			name:            "invalid schema structure in override",
 			documentContent: `{"user": {"name": "John"}}`,
 			refOverrides: map[string]interface{}{
 				"https://example.com/schemas/user.json": invalidSchemaOverrideFile,
@@ -723,18 +723,18 @@ func TestDataSourceJsonschemaValidatorRead_SchemaCompilationErrors(t *testing.T)
 	}
 
 	tests := []struct {
-		name          string
-		schemaFile    string
+		name            string
+		schemaFile      string
 		documentContent string
-		expectError   bool
-		errorContains string
+		expectError     bool
+		errorContains   string
 	}{
 		{
-			name:          "invalid type in schema",
-			schemaFile:    invalidSchemaFile,
+			name:            "invalid type in schema",
+			schemaFile:      invalidSchemaFile,
 			documentContent: `{"name": "test"}`,
-			expectError:   true,
-			errorContains: "failed to compile schema",
+			expectError:     true,
+			errorContains:   "failed to compile schema",
 		},
 	}
 

--- a/internal/provider/data_source_validation_test.go
+++ b/internal/provider/data_source_validation_test.go
@@ -1,7 +1,7 @@
 package provider
 
 import (
-validator "github.com/iilei/terraform-provider-jsonschema/pkg/jsonschema"
+	validator "github.com/iilei/terraform-provider-jsonschema/pkg/jsonschema"
 	"testing"
 )
 
@@ -15,10 +15,10 @@ func TestDataSourceValidationLogic(t *testing.T) {
 		expectedResult string
 	}{
 		{
-			name:           "valid config creation",
-			document:       `{"test": "value"}`,
-			schemaVersion:  "draft-07",
-			expectError:    false,
+			name:          "valid config creation",
+			document:      `{"test": "value"}`,
+			schemaVersion: "draft-07",
+			expectError:   false,
 		},
 		{
 			name:          "invalid schema version",
@@ -27,9 +27,9 @@ func TestDataSourceValidationLogic(t *testing.T) {
 			expectError:   true,
 		},
 		{
-			name:        "JSON5 document parsing",
-			document:    `{test: "value", /* comment */}`,
-			expectError: false,
+			name:           "JSON5 document parsing",
+			document:       `{test: "value", /* comment */}`,
+			expectError:    false,
 			expectedResult: `{"test":"value"}`,
 		},
 		{
@@ -80,10 +80,10 @@ func TestDataSourceValidationLogic(t *testing.T) {
 
 func TestDataSourceSchemaStructure(t *testing.T) {
 	ds := dataSourceJsonschemaValidator()
-	
+
 	// Test that all required fields are present in the schema
 	expectedFields := []string{"document", "schema", "schema_version", "error_message_template"}
-	
+
 	for _, field := range expectedFields {
 		if _, ok := ds.Schema[field]; !ok {
 			t.Errorf("expected field %q to be present in data source schema", field)
@@ -104,13 +104,13 @@ func TestDataSourceSchemaStructure(t *testing.T) {
 // Mock helper for testing configuration combinations
 func TestConfigurationOverrides(t *testing.T) {
 	tests := []struct {
-		name                    string
-		providerSchemaVersion   string
-		providerErrorTemplate   string
-		resourceSchemaVersion   string
-		resourceErrorTemplate   string
-		expectedSchemaVersion   string
-		expectedErrorTemplate   string
+		name                  string
+		providerSchemaVersion string
+		providerErrorTemplate string
+		resourceSchemaVersion string
+		resourceErrorTemplate string
+		expectedSchemaVersion string
+		expectedErrorTemplate string
 	}{
 		{
 			name:                  "provider defaults only",

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -27,7 +27,6 @@ func New(version string) func() *schema.Provider {
 					Default:     "{{.FullMessage}}",
 					Description: "Default error message template for validation failures. Can be overridden per data source. Available variables: {{.SchemaFile}}, {{.Document}}, {{.FullMessage}}, {{.Errors}}, {{.ErrorCount}}. Use {{range .Errors}} to iterate over individual errors.",
 				},
-
 			},
 			DataSourcesMap: map[string]*schema.Resource{
 				"jsonschema_validator": dataSourceJsonschemaValidator(),

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -90,7 +90,7 @@ func TestProviderConfigureFunction(t *testing.T) {
 		{
 			name: "valid configuration with all fields",
 			configData: map[string]interface{}{
-				"schema_version":        "draft-07",
+				"schema_version":         "draft-07",
 				"error_message_template": "Error in {schema}: {error}",
 			},
 			expectError: false,
@@ -98,7 +98,7 @@ func TestProviderConfigureFunction(t *testing.T) {
 		{
 			name: "valid configuration with defaults",
 			configData: map[string]interface{}{
-				"schema_version":        "draft/2020-12",
+				"schema_version":         "draft/2020-12",
 				"error_message_template": "{{range .Errors}}{{.Message}}{{end}}",
 			},
 			expectError: false,
@@ -106,7 +106,7 @@ func TestProviderConfigureFunction(t *testing.T) {
 		{
 			name: "invalid schema version",
 			configData: map[string]interface{}{
-				"schema_version":        "invalid-draft",
+				"schema_version":         "invalid-draft",
 				"error_message_template": "",
 			},
 			expectError:   true,
@@ -115,7 +115,7 @@ func TestProviderConfigureFunction(t *testing.T) {
 		{
 			name: "empty configuration (should use defaults)",
 			configData: map[string]interface{}{
-				"schema_version":        "",
+				"schema_version":         "",
 				"error_message_template": "",
 			},
 			expectError: false,
@@ -172,7 +172,7 @@ func TestProviderConfigureFunction(t *testing.T) {
 			expectedSchemaVersion := tt.configData["schema_version"].(string)
 			// When schema_version is empty, it's stored as-is (empty string) in DefaultSchemaVersion
 			// The default draft is set to Draft2020 in the DefaultDraft field instead
-			
+
 			if config.DefaultSchemaVersion != expectedSchemaVersion {
 				t.Errorf("expected schema version %q, got %q", expectedSchemaVersion, config.DefaultSchemaVersion)
 			}
@@ -193,7 +193,7 @@ func TestProviderSchemaDefinition(t *testing.T) {
 
 	// Test that all expected schema fields exist
 	expectedFields := []string{"schema_version", "error_message_template"}
-	
+
 	for _, field := range expectedFields {
 		if _, exists := provider.Schema[field]; !exists {
 			t.Errorf("expected schema field %q not found", field)

--- a/internal/provider/validation_integration_test.go
+++ b/internal/provider/validation_integration_test.go
@@ -1,21 +1,21 @@
 package provider
 
 import (
-validator "github.com/iilei/terraform-provider-jsonschema/pkg/jsonschema"
 	"encoding/json"
+	validator "github.com/iilei/terraform-provider-jsonschema/pkg/jsonschema"
 	"testing"
-	
+
 	"github.com/santhosh-tekuri/jsonschema/v6"
 )
 
 // Test the actual validation schema and compiler behavior
 func TestSchemaCompilationAndValidation(t *testing.T) {
 	tests := []struct {
-		name       string
-		schema     string
-		document   string
-		version    string
-		expectErr  bool
+		name      string
+		schema    string
+		document  string
+		version   string
+		expectErr bool
 	}{
 		{
 			name: "draft-07 validation success",
@@ -77,7 +77,7 @@ func TestSchemaCompilationAndValidation(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// Test schema compilation using v6 API
 			compiler := jsonschema.NewCompiler()
-			
+
 			// Parse the schema JSON
 			var schemaData interface{}
 			if err := json.Unmarshal([]byte(tt.schema), &schemaData); err != nil {
@@ -86,7 +86,7 @@ func TestSchemaCompilationAndValidation(t *testing.T) {
 				}
 				return // Expected parsing error
 			}
-			
+
 			// Add resource and compile
 			schemaURL := "test-schema"
 			if err := compiler.AddResource(schemaURL, schemaData); err != nil {
@@ -95,7 +95,7 @@ func TestSchemaCompilationAndValidation(t *testing.T) {
 				}
 				return // Expected compilation error
 			}
-			
+
 			schema, err := compiler.Compile(schemaURL)
 			if err != nil {
 				if !tt.expectErr {
@@ -118,22 +118,22 @@ func TestSchemaCompilationAndValidation(t *testing.T) {
 			if tt.expectErr && err == nil {
 				t.Errorf("expected validation error but got none")
 			}
-                        if !tt.expectErr && err != nil {
-                                t.Errorf("unexpected validation error: %v", err)
-                        }
-                })
-        }
+			if !tt.expectErr && err != nil {
+				t.Errorf("unexpected validation error: %v", err)
+			}
+		})
+	}
 }
 
 // Test actual validation errors with custom error templates
 func TestValidationErrorTemplateIntegration(t *testing.T) {
 	tests := []struct {
-		name           string
-		schema         string
-		document       string  
-		errorTemplate  string
-		expectedError  string
-		version        string
+		name          string
+		schema        string
+		document      string
+		errorTemplate string
+		expectedError string
+		version       string
 	}{
 		{
 			name: "simple template with validation error",
@@ -145,10 +145,10 @@ func TestValidationErrorTemplateIntegration(t *testing.T) {
 					"age": {"type": "integer", "minimum": 0}
 				}
 			}`,
-			document: `{"name": "John"}`, // Missing required "age"
+			document:      `{"name": "John"}`, // Missing required "age"
 			errorTemplate: "Config error: {{.FullMessage}}",
 			expectedError: "Config error: jsonschema validation failed with 'test://schema.json#'\n- at '': missing property 'age'",
-			version: "draft-07",
+			version:       "draft-07",
 		},
 		{
 			name: "detailed template with all variables",
@@ -158,10 +158,10 @@ func TestValidationErrorTemplateIntegration(t *testing.T) {
 					"port": {"type": "integer", "minimum": 1, "maximum": 65535}
 				}
 			}`,
-			document: `{"port": "8080"}`, // Wrong type - string instead of integer
+			document:      `{"port": "8080"}`, // Wrong type - string instead of integer
 			errorTemplate: "Schema: {{.SchemaFile}} | Error: {{.FullMessage}} | Document: {{.Document}}",
 			expectedError: "Schema: test://schema.json | Error: jsonschema validation failed with 'test://schema.json#'\n- at '/port': got string, want integer | Document: {\"port\": \"8080\"}",
-			version: "draft/2020-12",
+			version:       "draft/2020-12",
 		},
 		{
 			name: "go template syntax",
@@ -170,10 +170,10 @@ func TestValidationErrorTemplateIntegration(t *testing.T) {
 				"items": {"type": "string"},
 				"minItems": 2
 			}`,
-			document: `["single"]`, // Array too short
+			document:      `["single"]`, // Array too short
 			errorTemplate: "Validation failed in {{.SchemaFile}}: {{.FullMessage}}",
 			expectedError: "Validation failed in test://schema.json: jsonschema validation failed with 'test://schema.json#'\n- at '': minItems: got 1, want 2",
-			version: "draft-07",
+			version:       "draft-07",
 		},
 		{
 			name: "ci/cd format template",
@@ -184,10 +184,10 @@ func TestValidationErrorTemplateIntegration(t *testing.T) {
 					"version": {"type": "string", "pattern": "^v[0-9]+\\.[0-9]+\\.[0-9]+$"}
 				}
 			}`,
-			document: `{"version": "invalid-version"}`, // Invalid version format
+			document:      `{"version": "invalid-version"}`, // Invalid version format
 			errorTemplate: "::error file={{.SchemaFile}}::{{.FullMessage}}",
 			expectedError: "::error file=test://schema.json::jsonschema validation failed with 'test://schema.json#'\n- at '/version': 'invalid-version' does not match pattern '^v[0-9]+\\\\.[0-9]+\\\\.[0-9]+$'",
-			version: "draft-06",
+			version:       "draft-06",
 		},
 		{
 			name: "type mismatch with custom message",
@@ -198,10 +198,10 @@ func TestValidationErrorTemplateIntegration(t *testing.T) {
 					"timeout": {"type": "number", "minimum": 0}
 				}
 			}`,
-			document: `{"enabled": "yes", "timeout": -5}`, // Multiple errors
+			document:      `{"enabled": "yes", "timeout": -5}`, // Multiple errors
 			errorTemplate: "Configuration validation failed: {{.FullMessage}} (check your settings)",
 			expectedError: "Configuration validation failed: jsonschema validation failed with 'test://schema.json#'\n- at '/enabled': got string, want boolean\n- at '/timeout': minimum: got -5, want 0 (check your settings)",
-			version: "draft/2019-09",
+			version:       "draft/2019-09",
 		},
 	}
 
@@ -219,7 +219,7 @@ func TestValidationErrorTemplateIntegration(t *testing.T) {
 				t.Fatalf("failed to parse document: %v", err)
 			}
 
-			// Parse the schema  
+			// Parse the schema
 			schemaData, err := validator.ParseJSON5String(tt.schema)
 			if err != nil {
 				t.Fatalf("failed to parse schema: %v", err)
@@ -242,12 +242,12 @@ func TestValidationErrorTemplateIntegration(t *testing.T) {
 			if err := json.Unmarshal([]byte(schemaJSON), &parsedSchema); err != nil {
 				t.Fatalf("failed to parse schema JSON: %v", err)
 			}
-			
+
 			schemaURL := "test://schema.json"
 			if err := compiler.AddResource(schemaURL, parsedSchema); err != nil {
 				t.Fatalf("failed to add schema resource: %v", err)
 			}
-			
+
 			compiledSchema, err := compiler.Compile(schemaURL)
 			if err != nil {
 				t.Fatalf("failed to compile schema: %v", err)
@@ -341,7 +341,7 @@ func TestJSON5ValidationIntegration(t *testing.T) {
 			}`,
 			errorTemplate: "JSON5 validation error: {{.FullMessage}}",
 			expectedError: "JSON5 validation error: jsonschema validation failed with 'test://json5-schema.json#'\n- at '/name': minLength: got 2, want 3",
-			expectError: true,
+			expectError:   true,
 		},
 	}
 
@@ -370,12 +370,12 @@ func TestJSON5ValidationIntegration(t *testing.T) {
 			if err := json.Unmarshal([]byte(schemaJSON), &parsedSchema); err != nil {
 				t.Fatalf("failed to parse schema JSON: %v", err)
 			}
-			
+
 			schemaURL := "test://json5-schema.json"
 			if err := compiler.AddResource(schemaURL, parsedSchema); err != nil {
 				t.Fatalf("failed to add schema resource: %v", err)
 			}
-			
+
 			compiledSchema, err := compiler.Compile(schemaURL)
 			if err != nil {
 				t.Fatalf("failed to compile schema: %v", err)
@@ -383,7 +383,7 @@ func TestJSON5ValidationIntegration(t *testing.T) {
 
 			// Validate
 			validationErr := compiledSchema.Validate(documentData)
-			
+
 			if tt.expectError {
 				if validationErr == nil {
 					t.Errorf("expected validation error but got none")
@@ -418,37 +418,37 @@ func TestJSON5ValidationIntegration(t *testing.T) {
 // Test configuration resolution between provider and resource levels
 func TestConfigurationResolution(t *testing.T) {
 	tests := []struct {
-		name                      string
-		providerSchemaVersion     string
-		providerErrorTemplate     string
-		resourceSchemaVersion     string
-		resourceErrorTemplate     string
-		expectedFinalVersion      string
+		name                       string
+		providerSchemaVersion      string
+		providerErrorTemplate      string
+		resourceSchemaVersion      string
+		resourceErrorTemplate      string
+		expectedFinalVersion       string
 		expectedFinalErrorTemplate string
 	}{
 		{
-			name:                      "all provider defaults",
-			providerSchemaVersion:     "draft-07",
-			providerErrorTemplate:     "Provider: {{.FullMessage}}",
-			expectedFinalVersion:      "draft-07",
+			name:                       "all provider defaults",
+			providerSchemaVersion:      "draft-07",
+			providerErrorTemplate:      "Provider: {{.FullMessage}}",
+			expectedFinalVersion:       "draft-07",
 			expectedFinalErrorTemplate: "Provider: {{.FullMessage}}",
 		},
 		{
-			name:                      "resource overrides all",
-			providerSchemaVersion:     "draft-07",
-			providerErrorTemplate:     "Provider: {{.FullMessage}}",
-			resourceSchemaVersion:     "draft-04",
-			resourceErrorTemplate:     "Resource: {{.FullMessage}}",
-			expectedFinalVersion:      "draft-04",
+			name:                       "resource overrides all",
+			providerSchemaVersion:      "draft-07",
+			providerErrorTemplate:      "Provider: {{.FullMessage}}",
+			resourceSchemaVersion:      "draft-04",
+			resourceErrorTemplate:      "Resource: {{.FullMessage}}",
+			expectedFinalVersion:       "draft-04",
 			expectedFinalErrorTemplate: "Resource: {{.FullMessage}}",
 		},
 		{
-			name:                      "partial resource override",
-			providerSchemaVersion:     "draft-07",
-			providerErrorTemplate:     "Provider: {{.FullMessage}}",
-			resourceSchemaVersion:     "draft-04",
+			name:                  "partial resource override",
+			providerSchemaVersion: "draft-07",
+			providerErrorTemplate: "Provider: {{.FullMessage}}",
+			resourceSchemaVersion: "draft-04",
 			// resource doesn't specify error template
-			expectedFinalVersion:      "draft-04",
+			expectedFinalVersion:       "draft-04",
 			expectedFinalErrorTemplate: "Provider: {{.FullMessage}}",
 		},
 	}
@@ -486,15 +486,15 @@ func TestConfigurationResolution(t *testing.T) {
 // Test edge cases for validation
 func TestValidationEdgeCases(t *testing.T) {
 	tests := []struct {
-		name     string
-		schema   string
-		document string
+		name      string
+		schema    string
+		document  string
 		expectErr bool
 	}{
 		{
-			name: "empty schema",
-			schema: `{}`,
-			document: `{"anything": "goes"}`,
+			name:      "empty schema",
+			schema:    `{}`,
+			document:  `{"anything": "goes"}`,
 			expectErr: false, // Empty schema should allow anything
 		},
 		{
@@ -508,7 +508,7 @@ func TestValidationEdgeCases(t *testing.T) {
 					"testDef": {"type": "string"}
 				}
 			}`,
-			document: `{"test": "value"}`,
+			document:  `{"test": "value"}`,
 			expectErr: false,
 		},
 		{
@@ -544,7 +544,7 @@ func TestValidationEdgeCases(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// Compile schema using v6 API
 			compiler := jsonschema.NewCompiler()
-			
+
 			var schemaData interface{}
 			if err := json.Unmarshal([]byte(tt.schema), &schemaData); err != nil {
 				if !tt.expectErr {
@@ -552,7 +552,7 @@ func TestValidationEdgeCases(t *testing.T) {
 				}
 				return
 			}
-			
+
 			schemaURL := "test-schema"
 			if err := compiler.AddResource(schemaURL, schemaData); err != nil {
 				if !tt.expectErr {
@@ -560,7 +560,7 @@ func TestValidationEdgeCases(t *testing.T) {
 				}
 				return
 			}
-			
+
 			schema, err := compiler.Compile(schemaURL)
 			if err != nil {
 				if !tt.expectErr {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -119,20 +119,20 @@ func (s *SchemaConfig) GetEffectiveForceFiletype(flagValue string) string {
 // Later sources override earlier ones (command-line > config file > defaults)
 func MergeRefOverrides(sources ...map[string]string) map[string]string {
 	result := make(map[string]string)
-	
+
 	for _, source := range sources {
 		for key, value := range source {
 			result[key] = value
 		}
 	}
-	
+
 	return result
 }
 
 // ExpandDocumentGlobs expands glob patterns in document paths
 func (s *SchemaConfig) ExpandDocumentGlobs() ([]string, error) {
 	var expanded []string
-	
+
 	for _, pattern := range s.Documents {
 		// Check if pattern contains glob characters
 		if !containsGlobChars(pattern) {
@@ -140,22 +140,22 @@ func (s *SchemaConfig) ExpandDocumentGlobs() ([]string, error) {
 			expanded = append(expanded, pattern)
 			continue
 		}
-		
+
 		// Expand glob pattern
 		matches, err := filepath.Glob(pattern)
 		if err != nil {
 			return nil, fmt.Errorf("invalid glob pattern %q: %w", pattern, err)
 		}
-		
+
 		if len(matches) == 0 {
 			// No matches found - this might be intentional (e.g., no files yet)
 			// Don't treat as error, just skip
 			continue
 		}
-		
+
 		expanded = append(expanded, matches...)
 	}
-	
+
 	return expanded, nil
 }
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -191,10 +191,10 @@ func TestSchemaConfig_GetEffectiveErrorTemplate(t *testing.T) {
 
 func TestSchemaConfig_GetEffectiveForceFiletype(t *testing.T) {
 	tests := []struct {
-		name              string
-		configForceType   string
-		flagForceType     string
-		want              string
+		name            string
+		configForceType string
+		flagForceType   string
+		want            string
 	}{
 		{
 			name:            "flag takes precedence",
@@ -332,7 +332,7 @@ func TestSchemaConfig_ExpandDocumentGlobs(t *testing.T) {
 			wantErr:   false,
 		},
 		{
-			name:      "mixed glob and non-glob",
+			name: "mixed glob and non-glob",
 			documents: []string{
 				filepath.Join(tempDir, "data.json"),
 				filepath.Join(tempDir, "config.*.json"),

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -190,8 +190,9 @@ func (l *Loader) loadPyprojectTOML() error {
 // Environment variables use SCREAMING_SNAKE_CASE (no camelCase!)
 // Prefixed with the configured prefix (default: JSONSCHEMA_VALIDATOR_)
 // Examples (with default prefix):
-//   JSONSCHEMA_VALIDATOR_SCHEMA_VERSION=draft/2020-12
-//   JSONSCHEMA_VALIDATOR_ERROR_TEMPLATE="..."
+//
+//	JSONSCHEMA_VALIDATOR_SCHEMA_VERSION=draft/2020-12
+//	JSONSCHEMA_VALIDATOR_ERROR_TEMPLATE="..."
 func (l *Loader) loadEnvVars() error {
 	return l.k.Load(env.Provider(l.envPrefix, ".", func(s string) string {
 		// Convert JSONSCHEMA_VALIDATOR_SCHEMA_VERSION to schema_version

--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -256,7 +256,7 @@ func TestLoader_CustomEnvPrefix(t *testing.T) {
 
 	loader := NewLoader()
 	loader.SetEnvPrefix("MY_APP_")
-	
+
 	cfg, err := loader.Load(nil)
 	if err != nil {
 		t.Fatalf("Load() failed: %v", err)
@@ -265,23 +265,23 @@ func TestLoader_CustomEnvPrefix(t *testing.T) {
 	if cfg.SchemaVersion != "draft/2020-12" {
 		t.Errorf("schema_version = %q, want %q", cfg.SchemaVersion, "draft/2020-12")
 	}
-	
+
 	if cfg.ErrorTemplate != "Custom: {{.FullMessage}}" {
 		t.Errorf("error_template = %q, want %q", cfg.ErrorTemplate, "Custom: {{.FullMessage}}")
 	}
-	
+
 	// Verify default prefix doesn't work
 	os.Setenv("JSONSCHEMA_VALIDATOR_SCHEMA_VERSION", "draft/2019-09")
 	defer os.Unsetenv("JSONSCHEMA_VALIDATOR_SCHEMA_VERSION")
-	
+
 	loader2 := NewLoader()
 	loader2.SetEnvPrefix("MY_APP_")
-	
+
 	cfg2, err := loader2.Load(nil)
 	if err != nil {
 		t.Fatalf("Load() failed: %v", err)
 	}
-	
+
 	// Should still use MY_APP_ prefix, not JSONSCHEMA_VALIDATOR_
 	if cfg2.SchemaVersion != "draft/2020-12" {
 		t.Errorf("schema_version = %q, want %q (should ignore JSONSCHEMA_VALIDATOR_ prefix)", cfg2.SchemaVersion, "draft/2020-12")
@@ -295,7 +295,7 @@ func TestLoader_LoadFlags(t *testing.T) {
 	flags.Parse([]string{"--schema.version", "draft/2019-09"})
 
 	loader := NewLoader()
-	
+
 	// Load flags using posflag provider
 	if err := loader.loadFlags(flags); err != nil {
 		t.Fatalf("Load flags failed: %v", err)
@@ -310,7 +310,7 @@ func TestLoader_LoadFlags(t *testing.T) {
 	if *schemaVersion != "draft/2019-09" {
 		t.Errorf("flag value = %q, want %q", *schemaVersion, "draft/2019-09")
 	}
-	
+
 	// Note: Flag to config field mapping happens in CLI main.go
 	// This test verifies the flag loading mechanism works
 }

--- a/pkg/jsonschema/deterministic.go
+++ b/pkg/jsonschema/deterministic.go
@@ -16,33 +16,33 @@ func MarshalDeterministic(data interface{}) ([]byte, error) {
 // sortKeys recursively sorts all map keys in the data structure to ensure deterministic output
 func sortKeys(data interface{}) interface{} {
 	v := reflect.ValueOf(data)
-	
+
 	switch v.Kind() {
 	case reflect.Map:
 		if v.Type().Key().Kind() == reflect.String {
 			// Create a new map with sorted keys
 			sortedMap := make(map[string]interface{})
 			keys := make([]string, 0, v.Len())
-			
+
 			// Collect all keys
 			for _, key := range v.MapKeys() {
 				keys = append(keys, key.String())
 			}
-			
+
 			// Sort keys
 			sort.Strings(keys)
-			
+
 			// Rebuild map with sorted keys and recursively sort values
 			for _, key := range keys {
 				value := v.MapIndex(reflect.ValueOf(key))
 				sortedMap[key] = sortKeys(value.Interface())
 			}
-			
+
 			return sortedMap
 		}
 		// For non-string keyed maps, return as-is (shouldn't happen in JSON)
 		return data
-		
+
 	case reflect.Slice, reflect.Array:
 		// Process each element in the slice/array
 		length := v.Len()
@@ -51,19 +51,19 @@ func sortKeys(data interface{}) interface{} {
 			result[i] = sortKeys(v.Index(i).Interface())
 		}
 		return result
-		
+
 	case reflect.Ptr:
 		if v.IsNil() {
 			return nil
 		}
 		return sortKeys(v.Elem().Interface())
-		
+
 	case reflect.Interface:
 		if v.IsNil() {
 			return nil
 		}
 		return sortKeys(v.Elem().Interface())
-		
+
 	default:
 		// For primitive types (string, int, bool, etc.), return as-is
 		return data
@@ -85,12 +85,12 @@ func CompactDeterministicJSON(data interface{}) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	
+
 	// Compact the JSON to remove unnecessary whitespace
 	var buf bytes.Buffer
 	if err := json.Compact(&buf, jsonBytes); err != nil {
 		return nil, fmt.Errorf("failed to compact JSON: %w", err)
 	}
-	
+
 	return buf.Bytes(), nil
 }

--- a/pkg/jsonschema/deterministic_test.go
+++ b/pkg/jsonschema/deterministic_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
-
 )
 
 func TestMarshalDeterministic(t *testing.T) {
@@ -235,7 +234,7 @@ func TestMarshalDeterministicStringErrorHandling(t *testing.T) {
 	invalidData := map[string]interface{}{
 		"function": func() {},
 	}
-	
+
 	result, err := MarshalDeterministicString(invalidData)
 	if err == nil {
 		t.Errorf("expected error for invalid data, got result: %s", result)
@@ -251,7 +250,7 @@ func TestCompactDeterministicJSONErrorHandling(t *testing.T) {
 	invalidData := map[string]interface{}{
 		"function": func() {},
 	}
-	
+
 	result, err := CompactDeterministicJSON(invalidData)
 	if err == nil {
 		t.Errorf("expected error for invalid data, got result: %s", result)
@@ -273,7 +272,7 @@ func TestSortKeysReflectionEdgeCases(t *testing.T) {
 			desc:  "Empty map with string keys should be handled correctly",
 		},
 		{
-			name:  "empty_int_keyed_map", 
+			name:  "empty_int_keyed_map",
 			input: map[int]interface{}{},
 			desc:  "Empty map with non-string keys should return as-is",
 		},
@@ -309,7 +308,7 @@ func TestSortKeysReflectionEdgeCases(t *testing.T) {
 			name: "map_with_complex_key_type",
 			input: map[interface{}]interface{}{
 				"string_key": "value1",
-				42:           "value2", 
+				42:           "value2",
 			},
 			desc: "Map with interface{} keys (non-string) should return as-is",
 		},
@@ -332,7 +331,7 @@ func TestSortKeysReflectionEdgeCases(t *testing.T) {
 				}(),
 				func() interface{} {
 					var p *int = nil
-					return p  
+					return p
 				}(),
 				func() interface{} {
 					i := 42
@@ -392,9 +391,9 @@ func TestSortKeysReflectionEdgeCases(t *testing.T) {
 					t.Errorf("sortKeys panicked on %s: %v", tt.desc, r)
 				}
 			}()
-			
+
 			result := sortKeys(tt.input)
-			
+
 			// Ensure result can be marshaled to JSON (basic validation)
 			_, err := json.Marshal(result)
 			if err != nil {
@@ -403,7 +402,7 @@ func TestSortKeysReflectionEdgeCases(t *testing.T) {
 					t.Errorf("sortKeys result for %s could not be marshaled: %v", tt.desc, err)
 				}
 			}
-			
+
 			// For nil inputs, expect nil output
 			if tt.input == nil && result != nil {
 				t.Errorf("Expected nil result for nil input, got: %v", result)
@@ -436,7 +435,7 @@ func TestSortKeysMapKeyTypeValidation(t *testing.T) {
 			createMap: func() interface{} {
 				return map[int]interface{}{
 					3: "three",
-					1: "one", 
+					1: "one",
 					2: "two",
 				}
 			},
@@ -472,11 +471,11 @@ func TestSortKeysMapKeyTypeValidation(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			input := tt.createMap()
 			result := sortKeys(input)
-			
+
 			// Convert both to JSON to compare
 			inputJSON, _ := json.Marshal(input)
 			resultJSON, _ := json.Marshal(result)
-			
+
 			if tt.shouldSort {
 				// For string-keyed maps, the result should be different (sorted)
 				// We can't easily test exact order without more complex logic,
@@ -502,15 +501,15 @@ func TestSortKeysCompleteReflectionCoverage(t *testing.T) {
 		input interface{}
 	}{
 		{
-			name: "empty_map_with_string_keys",
+			name:  "empty_map_with_string_keys",
 			input: make(map[string]interface{}),
 		},
 		{
-			name: "single_key_map",
+			name:  "single_key_map",
 			input: map[string]interface{}{"single": "value"},
 		},
 		{
-			name: "map_with_zero_length_after_filtering",
+			name:  "map_with_zero_length_after_filtering",
 			input: map[string]interface{}{},
 		},
 		{
@@ -534,17 +533,17 @@ func TestSortKeysCompleteReflectionCoverage(t *testing.T) {
 			},
 		},
 		{
-			name: "array_with_nil_elements",
+			name:  "array_with_nil_elements",
 			input: [3]interface{}{nil, nil, nil},
 		},
 		{
 			name: "map_value_type_edge_cases",
 			input: map[string]interface{}{
-				"nil_value":       nil,
-				"pointer_to_nil":  (*string)(nil),
-				"empty_slice":     []interface{}{},
-				"nil_slice":       []interface{}(nil),
-				"empty_map":       map[string]interface{}{},
+				"nil_value":      nil,
+				"pointer_to_nil": (*string)(nil),
+				"empty_slice":    []interface{}{},
+				"nil_slice":      []interface{}(nil),
+				"empty_map":      map[string]interface{}{},
 			},
 		},
 	}
@@ -559,7 +558,7 @@ func TestSortKeysCompleteReflectionCoverage(t *testing.T) {
 			}()
 
 			result := sortKeys(tt.input)
-			
+
 			// Verify the result is JSON-serializable (basic validation)
 			if result != nil {
 				_, err := json.Marshal(result)
@@ -623,18 +622,18 @@ func TestSortKeysInterfaceHandling(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := sortKeys(tt.input)
-			
+
 			// Marshal both to JSON for comparison
 			expectedJSON, err1 := json.Marshal(tt.expected)
 			resultJSON, err2 := json.Marshal(result)
-			
+
 			if err1 != nil {
 				t.Fatalf("Failed to marshal expected: %v", err1)
 			}
 			if err2 != nil {
 				t.Fatalf("Failed to marshal result: %v", err2)
 			}
-			
+
 			if string(expectedJSON) != string(resultJSON) {
 				t.Errorf("Expected %s, got %s", string(expectedJSON), string(resultJSON))
 			}
@@ -690,7 +689,7 @@ func TestMarshalDeterministicComplexNesting(t *testing.T) {
 			if err != nil {
 				t.Errorf("MarshalDeterministic failed: %v", err)
 			}
-			
+
 			// Verify result is valid JSON
 			var unmarshaled interface{}
 			if err := json.Unmarshal(result, &unmarshaled); err != nil {
@@ -703,12 +702,12 @@ func TestMarshalDeterministicComplexNesting(t *testing.T) {
 func TestSortKeysInterfaceWithNonNilElem(t *testing.T) {
 	// Test interface case where IsNil() is false and has non-nil elem
 	// This covers the reflect.Interface case lines 61-65
-	
+
 	// Create a struct that will be passed as interface{}
 	type testStruct struct {
 		Value string
 	}
-	
+
 	testData := map[string]interface{}{
 		"z_key": func() interface{} {
 			// Return a non-nil interface containing a non-nil value
@@ -727,22 +726,22 @@ func TestSortKeysInterfaceWithNonNilElem(t *testing.T) {
 			return iface
 		}(),
 	}
-	
+
 	// This should recursively handle the interface types
 	result := sortKeys(testData)
-	
+
 	// Verify it's JSON-serializable
 	jsonBytes, err := json.Marshal(result)
 	if err != nil {
 		t.Errorf("Failed to marshal result: %v", err)
 	}
-	
+
 	// Verify the keys are sorted
 	var resultMap map[string]interface{}
 	if err := json.Unmarshal(jsonBytes, &resultMap); err != nil {
 		t.Errorf("Failed to unmarshal result: %v", err)
 	}
-	
+
 	// Keys should be in sorted order in the JSON
 	if !strings.Contains(string(jsonBytes), `"a_key"`) {
 		t.Error("Expected a_key in result")
@@ -752,31 +751,31 @@ func TestSortKeysWithJSONNull(t *testing.T) {
 	// Test that unmarshaled JSON with null value triggers the reflect.Interface case
 	// When JSON is unmarshaled, null becomes interface{} with nil value
 	jsonData := `null`
-	
+
 	var data interface{}
 	if err := json.Unmarshal([]byte(jsonData), &data); err != nil {
 		t.Fatalf("Failed to unmarshal JSON: %v", err)
 	}
-	
+
 	// data should be nil after unmarshaling "null"
 	if data != nil {
 		t.Errorf("Expected nil after unmarshaling null, got: %v", data)
 	}
-	
+
 	// sortKeys should handle the null value (which is interface{} containing nil)
 	result := sortKeys(data)
-	
+
 	// Result should be nil
 	if result != nil {
 		t.Errorf("Expected nil result, got: %v", result)
 	}
-	
+
 	// Marshal back to JSON
 	resultJSON, err := MarshalDeterministic(result)
 	if err != nil {
 		t.Fatalf("Failed to marshal result: %v", err)
 	}
-	
+
 	// Verify null is preserved
 	expected := `null`
 	if string(resultJSON) != expected {
@@ -787,7 +786,7 @@ func TestSortKeysWithJSONNull(t *testing.T) {
 func TestSortKeysInterfaceNonNilWithValue(t *testing.T) {
 	// Test the reflect.Interface case where IsNil() is false and contains a value
 	// This specifically tests the return sortKeys(v.Elem().Interface()) path
-	
+
 	// Create data with interface{} values wrapping different types
 	jsonData := `{
 		"z_string": "last",
@@ -798,22 +797,22 @@ func TestSortKeysInterfaceNonNilWithValue(t *testing.T) {
 			"a_nested": null
 		}
 	}`
-	
+
 	var data interface{}
 	if err := json.Unmarshal([]byte(jsonData), &data); err != nil {
 		t.Fatalf("Failed to unmarshal JSON: %v", err)
 	}
-	
+
 	// When unmarshaling, the values in the map are interface{} wrapping concrete types
 	// sortKeys needs to recursively handle these interfaces
 	result := sortKeys(data)
-	
+
 	// Marshal back to JSON
 	resultJSON, err := MarshalDeterministic(result)
 	if err != nil {
 		t.Fatalf("Failed to marshal result: %v", err)
 	}
-	
+
 	// Verify keys are sorted and values are preserved, including nested null
 	expected := `{"a_number":42,"m_bool":true,"nested":{"a_nested":null,"z_nested":"value"},"z_string":"last"}`
 	if string(resultJSON) != expected {

--- a/pkg/jsonschema/errors_test.go
+++ b/pkg/jsonschema/errors_test.go
@@ -5,13 +5,13 @@ import (
 	"fmt"
 	"strings"
 	"testing"
-	
+
 	"github.com/santhosh-tekuri/jsonschema/v6"
 )
 
 func TestErrorMessageTemplating(t *testing.T) {
 	mockError := fmt.Errorf("required property 'name' missing")
-	
+
 	testCases := []struct {
 		name     string
 		template string
@@ -71,7 +71,7 @@ func TestErrorFormattingEdgeCases(t *testing.T) {
 	}
 
 	// Test all available variables
-	result3 := FormatValidationError(mockError, "test.schema.json", `{"test": true}`, 
+	result3 := FormatValidationError(mockError, "test.schema.json", `{"test": true}`,
 		"Error: {{.FullMessage}}, Schema: {{.SchemaFile}}, Count: {{.ErrorCount}}, Doc: {{.Document}}")
 	expected := `Error: validation error, Schema: test.schema.json, Count: 1, Doc: {"test": true}`
 	if result3.Error() != expected {
@@ -100,43 +100,43 @@ func TestFormatValidationErrorComplexScenarios(t *testing.T) {
 		expectedContains []string
 	}{
 		{
-			name:       "Go template with multiple variables",
-			err:        &MockValidationError{message: "validation failed", path: "/name"},
-			schemaPath: "/path/to/schema.json",
-			document:   `{"name": 123}`,
-			template:   "Error: {{.FullMessage}} | Schema: {{.SchemaFile}}",
+			name:             "Go template with multiple variables",
+			err:              &MockValidationError{message: "validation failed", path: "/name"},
+			schemaPath:       "/path/to/schema.json",
+			document:         `{"name": 123}`,
+			template:         "Error: {{.FullMessage}} | Schema: {{.SchemaFile}}",
 			expectedContains: []string{"Error:", "validation failed", "Schema:", "/path/to/schema.json"},
 		},
 		{
-			name:       "Template with error count",
-			err:        &MockValidationError{message: "type error", path: "/age"},
-			schemaPath: "user.schema.json",
-			document:   `{"age": "twenty"}`,
-			template:   "Found {{.ErrorCount}} error(s) in schema {{.SchemaFile}}: {{range .Errors}}{{.Message}}{{end}}",
+			name:             "Template with error count",
+			err:              &MockValidationError{message: "type error", path: "/age"},
+			schemaPath:       "user.schema.json",
+			document:         `{"age": "twenty"}`,
+			template:         "Found {{.ErrorCount}} error(s) in schema {{.SchemaFile}}: {{range .Errors}}{{.Message}}{{end}}",
 			expectedContains: []string{"Found 1 error(s)", "user.schema.json", "type error"},
 		},
 		{
-			name:       "Template with path iteration",
-			err:        &MockValidationError{message: "missing field"},
-			schemaPath: "schema.json",
-			document:   "{}",
-			template:   "{{range .Errors}}Path {{.DocumentPath}}: {{.Message}}{{end}}",
+			name:             "Template with path iteration",
+			err:              &MockValidationError{message: "missing field"},
+			schemaPath:       "schema.json",
+			document:         "{}",
+			template:         "{{range .Errors}}Path {{.DocumentPath}}: {{.Message}}{{end}}",
 			expectedContains: []string{"Path :", "missing field"},
 		},
 		{
-			name:       "Invalid Go template syntax",
-			err:        &MockValidationError{message: "test error"},
-			schemaPath: "test.json",
-			document:   "{}",
-			template:   "{{.Errors", // Missing closing braces
+			name:             "Invalid Go template syntax",
+			err:              &MockValidationError{message: "test error"},
+			schemaPath:       "test.json",
+			document:         "{}",
+			template:         "{{.Errors", // Missing closing braces
 			expectedContains: []string{"template parsing failed"},
 		},
 		{
-			name:       "Non-validation error",
-			err:        fmt.Errorf("generic error"),
-			schemaPath: "test.json",
-			document:   "{}",
-			template:   "Custom: {{.FullMessage}}",
+			name:             "Non-validation error",
+			err:              fmt.Errorf("generic error"),
+			schemaPath:       "test.json",
+			document:         "{}",
+			template:         "Custom: {{.FullMessage}}",
 			expectedContains: []string{"Custom:", "generic error"},
 		},
 	}
@@ -176,57 +176,57 @@ func TestNilErrorHandling(t *testing.T) {
 
 func TestGetCommonTemplate(t *testing.T) {
 	tests := []struct {
-		name       string
-		templateName string
-		expectFound bool
+		name             string
+		templateName     string
+		expectFound      bool
 		expectedTemplate string
 	}{
 		{
-			name:         "simple template",
-			templateName: "simple",
-			expectFound:  true,
+			name:             "simple template",
+			templateName:     "simple",
+			expectFound:      true,
 			expectedTemplate: "{{.FullMessage}}",
 		},
 		{
-			name:         "basic template",
-			templateName: "basic",
-			expectFound:  true,
+			name:             "basic template",
+			templateName:     "basic",
+			expectFound:      true,
 			expectedTemplate: "{{range .Errors}}{{.Message}}\n{{end}}",
 		},
 		{
-			name:         "detailed template",
-			templateName: "detailed",
-			expectFound:  true,
+			name:             "detailed template",
+			templateName:     "detailed",
+			expectFound:      true,
 			expectedTemplate: "{{.ErrorCount}} validation error(s) found:\n{{range $i, $e := .Errors}}{{add $i 1}}. {{.Message}} at {{.DocumentPath}}\n{{end}}",
 		},
 		{
-			name:         "with_path template",
-			templateName: "with_path",
-			expectFound:  true,
+			name:             "with_path template",
+			templateName:     "with_path",
+			expectFound:      true,
 			expectedTemplate: "{{range .Errors}}{{.DocumentPath}}: {{.Message}}\n{{end}}",
 		},
 		{
-			name:         "with_schema template",
-			templateName: "with_schema",
-			expectFound:  true,
+			name:             "with_schema template",
+			templateName:     "with_schema",
+			expectFound:      true,
 			expectedTemplate: "Schema {{.SchemaFile}} validation failed:\n{{.FullMessage}}",
 		},
 		{
-			name:         "verbose template",
-			templateName: "verbose",
-			expectFound:  true,
+			name:             "verbose template",
+			templateName:     "verbose",
+			expectFound:      true,
 			expectedTemplate: "Validation Results:\nSchema: {{.SchemaFile}}\nErrors: {{.ErrorCount}}\nFull Message: {{.FullMessage}}\n\nIndividual Errors:\n{{range $i, $e := .Errors}}Error {{add $i 1}}:\n  Document Path: {{.DocumentPath}}\n  Schema Path: {{.SchemaPath}}\n  Message: {{.Message}}{{if .Value}}\n  Value: {{.Value}}{{end}}\n\n{{end}}",
 		},
 		{
-			name:         "non-existent template",
-			templateName: "nonexistent",
-			expectFound:  false,
+			name:             "non-existent template",
+			templateName:     "nonexistent",
+			expectFound:      false,
 			expectedTemplate: "",
 		},
 		{
-			name:         "empty template name",
-			templateName: "",
-			expectFound:  false,
+			name:             "empty template name",
+			templateName:     "",
+			expectFound:      false,
 			expectedTemplate: "",
 		},
 	}
@@ -234,11 +234,11 @@ func TestGetCommonTemplate(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			template, found := GetCommonTemplate(tt.templateName)
-			
+
 			if found != tt.expectFound {
 				t.Errorf("GetCommonTemplate() found = %v, expectFound = %v", found, tt.expectFound)
 			}
-			
+
 			if found && template != tt.expectedTemplate {
 				t.Errorf("GetCommonTemplate() template = %v, expectedTemplate = %v", template, tt.expectedTemplate)
 			}
@@ -250,14 +250,14 @@ func TestValidationErrorSorting(t *testing.T) {
 	// Test that validation errors are consistently ordered
 	unsortedErrors := []ValidationErrorDetail{
 		{Message: "error at /z", DocumentPath: "/z"},
-		{Message: "error at /a", DocumentPath: "/a"},  
+		{Message: "error at /a", DocumentPath: "/a"},
 		{Message: "second error at /a", DocumentPath: "/a"},
 		{Message: "error at /b", DocumentPath: "/b"},
 	}
-	
+
 	// Sort using our function
 	sortValidationErrors(unsortedErrors)
-	
+
 	// Verify the order
 	expected := []ValidationErrorDetail{
 		{Message: "error at /a", DocumentPath: "/a"},
@@ -265,7 +265,7 @@ func TestValidationErrorSorting(t *testing.T) {
 		{Message: "error at /b", DocumentPath: "/b"},
 		{Message: "error at /z", DocumentPath: "/z"},
 	}
-	
+
 	for i, err := range unsortedErrors {
 		if err.DocumentPath != expected[i].DocumentPath || err.Message != expected[i].Message {
 			t.Errorf("Expected error %d to be %+v, got %+v", i, expected[i], err)
@@ -276,7 +276,7 @@ func TestValidationErrorSorting(t *testing.T) {
 func TestCommonErrorTemplatesExist(t *testing.T) {
 	// Test that all expected common templates exist
 	expectedTemplates := []string{"basic", "detailed", "simple", "with_path", "with_schema", "verbose"}
-	
+
 	for _, templateName := range expectedTemplates {
 		t.Run("template_"+templateName, func(t *testing.T) {
 			template, found := GetCommonTemplate(templateName)
@@ -483,9 +483,9 @@ func TestGenerateSortedFullMessage(t *testing.T) {
 		expectedParts []string
 	}{
 		{
-			name:     "error with multiple parts",
-			errorMsg: "validation error",
-			template: "{{.FullMessage}}",
+			name:          "error with multiple parts",
+			errorMsg:      "validation error",
+			template:      "{{.FullMessage}}",
 			expectedParts: []string{"validation error"},
 		},
 	}
@@ -494,7 +494,7 @@ func TestGenerateSortedFullMessage(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			mockErr := fmt.Errorf("%s", tt.errorMsg)
 			result := FormatValidationError(mockErr, "test.schema.json", `{"test": "data"}`, tt.template)
-			
+
 			for _, part := range tt.expectedParts {
 				if !strings.Contains(result.Error(), part) {
 					t.Errorf("Expected result to contain %q, got %q", part, result.Error())
@@ -511,9 +511,9 @@ func TestSortValidationErrorsSecondarySort(t *testing.T) {
 		{Message: "error a", DocumentPath: "/same"},
 		{Message: "error m", DocumentPath: "/same"},
 	}
-	
+
 	sortValidationErrors(errors)
-	
+
 	// Verify they are sorted alphabetically by message
 	if errors[0].Message != "error a" {
 		t.Errorf("Expected first error to be 'error a', got %q", errors[0].Message)
@@ -530,14 +530,14 @@ func TestFormatValidationErrorWithLongDocument(t *testing.T) {
 	// Test document truncation in error context
 	longDocument := strings.Repeat("x", 1000)
 	mockErr := fmt.Errorf("validation error")
-	
+
 	result := FormatValidationError(mockErr, "test.json", longDocument, "Doc: {{.Document}}")
-	
+
 	// Verify the document was truncated
 	if !strings.Contains(result.Error(), "...") {
 		t.Error("Expected document to be truncated in error message")
 	}
-	
+
 	// Verify error message is not absurdly long
 	if len(result.Error()) > 600 {
 		t.Errorf("Error message too long: %d characters", len(result.Error()))
@@ -547,10 +547,10 @@ func TestFormatValidationErrorWithLongDocument(t *testing.T) {
 func TestFormatValidationErrorTemplateAddFunction(t *testing.T) {
 	// Test the template's add function
 	mockErr := fmt.Errorf("validation error")
-	
-	result := FormatValidationError(mockErr, "test.json", `{"test": "data"}`, 
+
+	result := FormatValidationError(mockErr, "test.json", `{"test": "data"}`,
 		"Error {{add 1 2}}: {{.FullMessage}}")
-	
+
 	if !strings.Contains(result.Error(), "Error 3:") {
 		t.Errorf("Expected add function to work, got: %s", result.Error())
 	}
@@ -559,7 +559,7 @@ func TestFormatValidationErrorTemplateAddFunction(t *testing.T) {
 func TestFormatValidationErrorEdgeCaseTemplates(t *testing.T) {
 	// Test various template edge cases
 	mockErr := fmt.Errorf("test error")
-	
+
 	tests := []struct {
 		name     string
 		template string
@@ -581,7 +581,7 @@ func TestFormatValidationErrorEdgeCaseTemplates(t *testing.T) {
 			expected: "Has errors",
 		},
 	}
-	
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := FormatValidationError(mockErr, "test.json", `{}`, tt.template)
@@ -804,7 +804,7 @@ func TestExtractValueAtPath(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := extractValueAtPath(tt.data, tt.path)
-			
+
 			if tt.expected == "" && result != "" {
 				// Check if it's a truncation case
 				if !strings.Contains(result, "...") {
@@ -923,52 +923,52 @@ func TestValueFieldPopulationIntegration(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// Load schema
 			compiler := jsonschema.NewCompiler()
-			
+
 			// Parse schema
 			var schemaData interface{}
 			if err := json.Unmarshal([]byte(tt.schema), &schemaData); err != nil {
 				t.Fatalf("Failed to parse schema: %v", err)
 			}
-			
+
 			if err := compiler.AddResource("test.schema.json", schemaData); err != nil {
 				t.Fatalf("Failed to add schema: %v", err)
 			}
-			
+
 			schema, err := compiler.Compile("test.schema.json")
 			if err != nil {
 				t.Fatalf("Failed to compile schema: %v", err)
 			}
-			
+
 			// Parse document
 			var doc interface{}
 			if err := json.Unmarshal([]byte(tt.document), &doc); err != nil {
 				t.Fatalf("Failed to parse document: %v", err)
 			}
-			
+
 			// Validate
 			err = schema.Validate(doc)
 			if err == nil {
 				t.Fatal("Expected validation error, got none")
 			}
-			
+
 			// Type assert to ValidationError
 			validationErr, ok := err.(*jsonschema.ValidationError)
 			if !ok {
 				t.Fatalf("Expected *jsonschema.ValidationError, got %T", err)
 			}
-			
+
 			// Extract errors
 			errors := extractValidationErrors(validationErr, doc)
-			
+
 			// Verify Value field is populated correctly
 			for _, valErr := range errors {
 				expectedValue, exists := tt.expectedValues[valErr.DocumentPath]
 				if !exists {
 					continue // Not checking this error
 				}
-				
+
 				if valErr.Value != expectedValue {
-					t.Errorf("Path %s: expected value %q, got %q", 
+					t.Errorf("Path %s: expected value %q, got %q",
 						valErr.DocumentPath, expectedValue, valErr.Value)
 				}
 			}

--- a/pkg/jsonschema/json5.go
+++ b/pkg/jsonschema/json5.go
@@ -28,7 +28,7 @@ func JSON5ToJSON(content []byte) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	
+
 	return MarshalDeterministic(data)
 }
 
@@ -48,13 +48,13 @@ func (l JSON5FileLoader) Load(url string) (interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	
+
 	// Read and parse the file as JSON5
 	content, err := os.ReadFile(filePath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read file %q: %w", filePath, err)
 	}
-	
+
 	// Use our existing JSON5 parsing function
 	return ParseJSON5(content)
 }

--- a/pkg/jsonschema/json5_test.go
+++ b/pkg/jsonschema/json5_test.go
@@ -92,7 +92,7 @@ func TestParseJSON5String(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result, err := ParseJSON5String(tt.input)
-			
+
 			if tt.expectError {
 				if err == nil {
 					t.Errorf("expected error but got none")
@@ -172,7 +172,7 @@ func TestJSON5StringToJSON(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result, err := JSON5StringToJSON(tt.input)
-			
+
 			if tt.expectError {
 				if err == nil {
 					t.Errorf("expected error but got none")
@@ -216,7 +216,7 @@ func TestJSON5ToJSON(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result, err := JSON5ToJSON(tt.input)
-			
+
 			if tt.expectError {
 				if err == nil {
 					t.Errorf("expected error but got none")
@@ -240,7 +240,7 @@ func TestJSON5FileLoader(t *testing.T) {
 	// Create a temporary JSON5 file
 	tmpDir := t.TempDir()
 	json5File := filepath.Join(tmpDir, "test.json5")
-	
+
 	json5Content := `{
 		// JSON5 test file with comments
 		"name": "test",
@@ -249,30 +249,30 @@ func TestJSON5FileLoader(t *testing.T) {
 			"enabled": true
 		}
 	}`
-	
+
 	if err := os.WriteFile(json5File, []byte(json5Content), 0644); err != nil {
 		t.Fatalf("Failed to write test file: %v", err)
 	}
-	
+
 	// Test loading with JSON5FileLoader
 	loader := JSON5FileLoader{}
 	fileURL := fmt.Sprintf("file://%s", json5File)
-	
+
 	data, err := loader.Load(fileURL)
 	if err != nil {
 		t.Fatalf("Failed to load JSON5 file: %v", err)
 	}
-	
+
 	// Verify the loaded data
 	dataMap, ok := data.(map[string]interface{})
 	if !ok {
 		t.Fatalf("Expected map[string]interface{}, got %T", data)
 	}
-	
+
 	if dataMap["name"] != "test" {
 		t.Errorf("Expected name='test', got %v", dataMap["name"])
 	}
-	
+
 	if configMap, ok := dataMap["config"].(map[string]interface{}); !ok {
 		t.Errorf("Expected config to be map, got %T", dataMap["config"])
 	} else if configMap["enabled"] != true {
@@ -282,7 +282,7 @@ func TestJSON5FileLoader(t *testing.T) {
 
 func TestJSON5FileLoaderErrors(t *testing.T) {
 	loader := JSON5FileLoader{}
-	
+
 	t.Run("invalid URL scheme", func(t *testing.T) {
 		// Test with non-file URL that ToFile can't handle
 		_, err := loader.Load("http://example.com/schema.json")
@@ -290,7 +290,7 @@ func TestJSON5FileLoaderErrors(t *testing.T) {
 			t.Error("Expected error for non-file URL, got nil")
 		}
 	})
-	
+
 	t.Run("missing file", func(t *testing.T) {
 		// Test with valid file URL but missing file
 		missingFile := "file:///tmp/nonexistent_file_12345.json"
@@ -306,16 +306,16 @@ func TestJSON5FileLoaderErrors(t *testing.T) {
 			}
 		}
 	})
-	
+
 	t.Run("invalid JSON5 content", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		invalidFile := filepath.Join(tmpDir, "invalid.json5")
-		
+
 		// Write invalid JSON5 content
 		if err := os.WriteFile(invalidFile, []byte(`{invalid json`), 0644); err != nil {
 			t.Fatalf("Failed to write test file: %v", err)
 		}
-		
+
 		fileURL := fmt.Sprintf("file://%s", invalidFile)
 		_, err := loader.Load(fileURL)
 		if err == nil {
@@ -402,7 +402,7 @@ func TestParseJSON5EdgeCases(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result, err := ParseJSON5(tt.input)
-			
+
 			if tt.expectError {
 				if err == nil {
 					t.Errorf("%s: expected error but got none", tt.description)
@@ -421,10 +421,10 @@ func TestParseJSON5EdgeCases(t *testing.T) {
 
 func TestJSON5ToJSONEdgeCases(t *testing.T) {
 	tests := []struct {
-		name          string
-		input         []byte
-		expectError   bool
-		validateJSON  bool
+		name         string
+		input        []byte
+		expectError  bool
+		validateJSON bool
 	}{
 		{
 			name:         "complex nested structure",
@@ -454,7 +454,7 @@ func TestJSON5ToJSONEdgeCases(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result, err := JSON5ToJSON(tt.input)
-			
+
 			if tt.expectError {
 				if err == nil {
 					t.Error("expected error but got none")
@@ -480,7 +480,7 @@ func TestJSON5ToJSONEdgeCases(t *testing.T) {
 
 func TestJSON5FileLoaderWithVariousFormats(t *testing.T) {
 	tmpDir := t.TempDir()
-	
+
 	tests := []struct {
 		name        string
 		content     string


### PR DESCRIPTION
Hey there! 👋

First off, huge thanks for all the work you’ve put in — really appreciate it!

I wanted to chat about a few changes that are pretty important on my end, but I noticed Issues are turned off on your fork. Maybe you’d consider enabling them? Could make collaboration a lot smoother 🙂

While digging into my changes, I noticed the Go files aren’t formatted consistently. That can make things a bit tricky for other contributors, so I put together this PR to tidy up the formatting and keep everything neat.

Thanks for checking it out! 🙏