### PR TITLE
ci: add code quality gates to CI pipeline

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,9 +18,50 @@ on:
   # schedule:
   #   - cron: '0 13 * * *'
 jobs:
+  # verify code quality and formatting
+  lint:
+    name: Code Quality
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+
+    - name: Set up Go
+      uses: actions/setup-go@v6
+      with:
+        go-version: '1.25.3'
+      id: go
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v4
+
+    - name: Get dependencies
+      run: |
+        go mod download
+
+    - name: Verify go fmt
+      run: |
+        if [ -n "$(go fmt ./...)" ]; then
+          echo "ERROR: Code is not formatted with 'go fmt ./...'"
+          echo "Please run 'go fmt ./...' and commit the changes"
+          exit 1
+        fi
+        echo "✓ Code is properly formatted"
+
+    - name: Run go vet
+      run: |
+        go vet ./...
+        echo "✓ go vet passed"
+
+    - name: Run golangci-lint
+      uses: golangci/golangci-lint-action@v9
+      with:
+        version: latest
+        args: --timeout=5m
+
   # ensure the code builds...
   build:
     name: Build
+    needs: lint
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,75 @@
+version: "2"
+
+linters:
+  default: none
+  enable:
+    - govet
+    - ineffassign
+    - staticcheck
+    - unused
+    - unconvert
+  settings:
+    dupl:
+      threshold: 100
+    goconst:
+      min-len: 2
+      min-occurrences: 2
+    gocritic:
+      enabled-tags:
+        - diagnostic
+        - experimental
+        - opinionated
+        - performance
+        - style
+    gocyclo:
+      min-complexity: 15
+    govet:
+      enable-all: false
+      enable:
+        - atomic
+        - bools
+        - buildtag
+        - nilfunc
+        - printf
+    misspell:
+      locale: US
+    nolintlint:
+      allow-unused: false
+      require-explanation: true
+      require-specific: true
+  exclusions:
+    rules:
+      - path: '_test\.go'
+        linters:
+          - errcheck
+          - unparam
+        text: "always nil"
+      - path: 'cmd/'
+        linters:
+          - errcheck
+      - path: 'main\.go'
+        linters:
+          - staticcheck
+        text: "SA1019.*plugin.Debug"
+      - linters:
+          - staticcheck
+        text: "SA1019.*Read is deprecated"
+
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  settings:
+    gofmt:
+      simplify: false
+    goimports:
+      local-prefixes:
+        - github.com/iilei/terraform-provider-jsonschema
+
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
+
+run:
+  timeout: 5m
+  go: '1.25'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,30 @@
+# .pre-commit-config.yaml
+repos:
+  - repo: https://github.com/golangci/golangci-lint
+    rev: v2.6.2  # Use the latest version from https://github.com/golangci/golangci-lint/releases
+    hooks:
+      - id: golangci-lint
+        args: [--fix, --timeout=5m]
+
+  - repo: local
+    hooks:
+      - id: go-fmt
+        name: go fmt
+        entry: bash -c 'output=$(go fmt ./...); if [ -n "$output" ]; then echo "Files not formatted:"; echo "$output"; exit 1; fi'
+        language: system
+        types: [go]
+        pass_filenames: false
+
+      - id: go-vet
+        name: go vet
+        entry: bash -c 'go vet ./... || exit 0'
+        language: system
+        types: [go]
+        pass_filenames: false
+
+      - id: go-test
+        name: go test
+        entry: go test -short ./...
+        language: system
+        types: [go]
+        pass_filenames: false

--- a/cmd/jsonschema-validator/main.go
+++ b/cmd/jsonschema-validator/main.go
@@ -6,10 +6,11 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/iilei/terraform-provider-jsonschema/pkg/config"
-	validator "github.com/iilei/terraform-provider-jsonschema/pkg/jsonschema"
 	"github.com/santhosh-tekuri/jsonschema/v6"
 	"github.com/spf13/pflag"
+
+	"github.com/iilei/terraform-provider-jsonschema/pkg/config"
+	validator "github.com/iilei/terraform-provider-jsonschema/pkg/jsonschema"
 )
 
 const (
@@ -30,16 +31,16 @@ func main() {
 func run() error {
 	// Define flags
 	var (
-		showVersion      bool
-		showHelp         bool
-		configFile       string
-		schemaPath       string
-		schemaVersion    string
-		errorTemplate    string
-		refOverrides     []string
-		documents        []string
-		envPrefix        string
-		forceFiletype    string
+		showVersion   bool
+		showHelp      bool
+		configFile    string
+		schemaPath    string
+		schemaVersion string
+		errorTemplate string
+		refOverrides  []string
+		documents     []string
+		envPrefix     string
+		forceFiletype string
 	)
 
 	pflag.BoolVarP(&showVersion, "version", "v", false, "Show version and exit")
@@ -112,7 +113,7 @@ For more information, see: https://github.com/iilei/terraform-provider-jsonschem
 
 	// Load configuration
 	loader := config.NewLoader()
-	
+
 	// Set custom environment prefix if provided
 	if envPrefix != "" {
 		// Ensure prefix ends with underscore
@@ -121,11 +122,11 @@ For more information, see: https://github.com/iilei/terraform-provider-jsonschem
 		}
 		loader.SetEnvPrefix(envPrefix)
 	}
-	
+
 	// Load from specific config file if provided
 	var cfg *config.Config
 	var err error
-	
+
 	if configFile != "" {
 		cfg, err = loader.LoadFromFile(configFile)
 		if err != nil {
@@ -274,13 +275,13 @@ func validateSchema(schemaConfig config.SchemaConfig, globalConfig *config.Confi
 func validateDocument(docPath string, schema *jsonschema.Schema, schemaConfig config.SchemaConfig, globalConfig *config.Config, flagForceFiletype string) error {
 	// Get effective force_filetype: command-line flag > config file > auto-detect
 	effectiveForceFiletype := schemaConfig.GetEffectiveForceFiletype(flagForceFiletype)
-	
+
 	// Parse document file with optional forced file type
 	fileType := validator.FileType(effectiveForceFiletype)
 	if fileType == "" {
 		fileType = validator.FileTypeAuto
 	}
-	
+
 	docData, err := validator.ParseFile(docPath, fileType)
 	if err != nil {
 		return fmt.Errorf("failed to parse document %q: %w", docPath, err)

--- a/internal/provider/config.go
+++ b/internal/provider/config.go
@@ -10,13 +10,13 @@ import (
 type ProviderConfig struct {
 	// DefaultSchemaVersion specifies the JSON Schema version to use when not specified in the schema
 	DefaultSchemaVersion string
-	
+
 	// DefaultErrorTemplate is the default error message template
 	DefaultErrorTemplate string
-	
+
 	// DetailedErrors enables detailed structured error output
 	DetailedErrors bool
-	
+
 	// DefaultDraft is the default draft to use
 	DefaultDraft *jsonschema.Draft
 }
@@ -27,14 +27,14 @@ func NewProviderConfig(schemaVersion, errorTemplate string, detailedErrors bool)
 	if errorTemplate == "" {
 		errorTemplate = "{{.FullMessage}}"
 	}
-	
+
 	config := &ProviderConfig{
 		DefaultSchemaVersion: schemaVersion,
 		DefaultErrorTemplate: errorTemplate,
 		DetailedErrors:       detailedErrors,
 		DefaultDraft:         jsonschema.Draft2020, // Default to latest draft
 	}
-	
+
 	// Set draft based on schema version if provided
 	if schemaVersion != "" {
 		draft, err := GetDraftForVersion(schemaVersion)
@@ -43,7 +43,7 @@ func NewProviderConfig(schemaVersion, errorTemplate string, detailedErrors bool)
 		}
 		config.DefaultDraft = draft
 	}
-	
+
 	return config, nil
 }
 

--- a/internal/provider/config_test.go
+++ b/internal/provider/config_test.go
@@ -7,8 +7,8 @@ import (
 
 func TestNewProviderConfig(t *testing.T) {
 	tests := []struct {
-		name           string
-		schemaVersion  string
+		name          string
+		schemaVersion string
 		errorTemplate string
 		expectError   bool
 		errorContains string
@@ -107,7 +107,7 @@ func TestGetDraftForVersion(t *testing.T) {
 		{"draft/2019-09", false},
 		{"draft/2020-12", false},
 		{"invalid", true},
-		{"", true}, // empty should be invalid
+		{"", true},         // empty should be invalid
 		{"draft-05", true}, // non-existent version
 	}
 
@@ -171,7 +171,7 @@ func TestGetDraftForVersionURLFormats(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
 			draft, err := GetDraftForVersion(tt.version)
-			
+
 			if tt.expectError {
 				if err == nil {
 					t.Errorf("expected error for %s, but got none", tt.description)

--- a/internal/provider/coverage_improvement_test.go
+++ b/internal/provider/coverage_improvement_test.go
@@ -1,7 +1,6 @@
 package provider
 
 import (
-validator "github.com/iilei/terraform-provider-jsonschema/pkg/jsonschema"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -10,51 +9,58 @@ validator "github.com/iilei/terraform-provider-jsonschema/pkg/jsonschema"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/santhosh-tekuri/jsonschema/v6"
+
+	validator "github.com/iilei/terraform-provider-jsonschema/pkg/jsonschema"
 )
 
 // TestGenerateSortedFullMessage_EmptyErrors tests the case where ValidationError has no extracted details
 func TestGenerateSortedFullMessage_EmptyErrors(t *testing.T) {
 	// Create a ValidationError with no causes (empty error tree)
 	// This is a theoretical edge case where the error exists but has no extractable details
-	
+
 	// We need to create a schema that will compile and then manually construct
 	// a validation scenario that might not have detailed errors
-	
+
 	schemaJSON := `{
 		"$schema": "https://json-schema.org/draft/2020-12/schema",
 		"type": "object"
 	}`
-	
+
 	var schemaData interface{}
 	if err := json.Unmarshal([]byte(schemaJSON), &schemaData); err != nil {
 		t.Fatalf("Failed to parse schema: %v", err)
 	}
-	
+
 	compiler := jsonschema.NewCompiler()
 	compiler.DefaultDraft(jsonschema.Draft2020)
-	
+
 	if err := compiler.AddResource("test://schema", schemaData); err != nil {
 		t.Fatalf("Failed to add schema: %v", err)
 	}
-	
+
 	compiledSchema, err := compiler.Compile("test://schema")
 	if err != nil {
 		t.Fatalf("Failed to compile schema: %v", err)
 	}
-	
+
 	// Try to validate something that will fail at a fundamental level
 	// Using a non-object type when object is required
 	err = compiledSchema.Validate("not an object")
 	if err == nil {
 		t.Fatal("Expected validation to fail")
 	}
-	
+
 	// Check if we can format this error
-	result := validator.FormatValidationError(err, "test.json", `"not an object"`, "{{.FullMessage}}")
+	result := validator.FormatValidationError(
+		err,
+		"test.json",
+		`"not an object"`,
+		"{{.FullMessage}}",
+	)
 	if result == nil {
 		t.Fatal("Expected error result")
 	}
-	
+
 	// The message should still contain the schema URL even if no detailed errors
 	errMsg := result.Error()
 	if !strings.Contains(errMsg, "test://schema") || !strings.Contains(errMsg, "validation") {
@@ -67,7 +73,7 @@ func TestDataSourceJsonschemaValidatorRead_NoDraftConfiguration(t *testing.T) {
 	// Create a temporary schema file without $schema field
 	tempDir := t.TempDir()
 	schemaPath := filepath.Join(tempDir, "test.schema.json")
-	
+
 	schemaContent := `{
 		"type": "object",
 		"properties": {
@@ -75,44 +81,44 @@ func TestDataSourceJsonschemaValidatorRead_NoDraftConfiguration(t *testing.T) {
 		},
 		"required": ["name"]
 	}`
-	
-	if err := os.WriteFile(schemaPath, []byte(schemaContent), 0644); err != nil {
+
+	if err := os.WriteFile(schemaPath, []byte(schemaContent), 0o644); err != nil {
 		t.Fatalf("Failed to create schema file: %v", err)
 	}
 
 	// Create document file
 	docPath := filepath.Join(tempDir, "test.json")
-	if err := os.WriteFile(docPath, []byte(`{"name": "test"}`), 0644); err != nil {
+	if err := os.WriteFile(docPath, []byte(`{"name": "test"}`), 0o644); err != nil {
 		t.Fatalf("Failed to create document file: %v", err)
 	}
-	
+
 	// Create resource data
 	d := schema.TestResourceDataRaw(t, map[string]*schema.Schema{
-		"document": {Type: schema.TypeString},
-		"schema":   {Type: schema.TypeString},
-		"schema_version": {Type: schema.TypeString},
+		"document":               {Type: schema.TypeString},
+		"schema":                 {Type: schema.TypeString},
+		"schema_version":         {Type: schema.TypeString},
 		"error_message_template": {Type: schema.TypeString},
-		"ref_overrides": {Type: schema.TypeMap},
-		"valid_json": {Type: schema.TypeString},
+		"ref_overrides":          {Type: schema.TypeMap},
+		"valid_json":             {Type: schema.TypeString},
 	}, map[string]interface{}{
-		"document": docPath,
-		"schema":   schemaPath,
+		"document":       docPath,
+		"schema":         schemaPath,
 		"schema_version": "", // No version specified
 	})
-	
+
 	// Create provider config with NO default schema version and NO default draft
 	config := &ProviderConfig{
-		DefaultSchemaVersion: "", // Empty - no default
+		DefaultSchemaVersion: "",  // Empty - no default
 		DefaultDraft:         nil, // Nil - no default draft
 		DefaultErrorTemplate: "",
 	}
-	
+
 	// This should trigger the fallback to Draft2020 (line 121)
 	err := dataSourceJsonschemaValidatorRead(d, config)
 	if err != nil {
 		t.Fatalf("Expected validation to succeed with Draft2020 fallback: %v", err)
 	}
-	
+
 	// Verify the document was validated successfully
 	validJson := d.Get("valid_json").(string)
 	if validJson == "" {
@@ -129,7 +135,7 @@ func TestDataSourceJsonschemaValidatorRead_DuplicateSchemaURL(t *testing.T) {
 	// Create a temporary schema file
 	tempDir := t.TempDir()
 	schemaPath := filepath.Join(tempDir, "test.schema.json")
-	
+
 	schemaContent := `{
 		"$schema": "https://json-schema.org/draft/2020-12/schema",
 		"type": "object",
@@ -137,45 +143,45 @@ func TestDataSourceJsonschemaValidatorRead_DuplicateSchemaURL(t *testing.T) {
 			"name": {"type": "string"}
 		}
 	}`
-	
-	if err := os.WriteFile(schemaPath, []byte(schemaContent), 0644); err != nil {
+
+	if err := os.WriteFile(schemaPath, []byte(schemaContent), 0o644); err != nil {
 		t.Fatalf("Failed to create schema file: %v", err)
 	}
 
 	// Create document file
 	docPath := filepath.Join(tempDir, "test.json")
-	if err := os.WriteFile(docPath, []byte(`{"name": "test"}`), 0644); err != nil {
+	if err := os.WriteFile(docPath, []byte(`{"name": "test"}`), 0o644); err != nil {
 		t.Fatalf("Failed to create document file: %v", err)
 	}
-	
+
 	// Create resource data
 	d := schema.TestResourceDataRaw(t, map[string]*schema.Schema{
-		"document": {Type: schema.TypeString},
-		"schema":   {Type: schema.TypeString},
-		"schema_version": {Type: schema.TypeString},
+		"document":               {Type: schema.TypeString},
+		"schema":                 {Type: schema.TypeString},
+		"schema_version":         {Type: schema.TypeString},
 		"error_message_template": {Type: schema.TypeString},
-		"ref_overrides": {Type: schema.TypeMap},
-		"valid_json": {Type: schema.TypeString},
+		"ref_overrides":          {Type: schema.TypeMap},
+		"valid_json":             {Type: schema.TypeString},
 	}, map[string]interface{}{
 		"document": docPath,
 		"schema":   schemaPath,
 	})
-	
+
 	config := &ProviderConfig{
 		DefaultSchemaVersion: "draft/2020-12",
 		DefaultErrorTemplate: "",
 	}
-	
+
 	// First call should succeed
 	err := dataSourceJsonschemaValidatorRead(d, config)
 	if err != nil {
 		t.Fatalf("First validation failed: %v", err)
 	}
-	
+
 	// Note: We can't easily trigger the AddResource error in lines 158-159
 	// because each call to dataSourceJsonschemaValidatorRead creates a new compiler
 	// instance, so there's no way to get duplicate registrations.
-	// 
+	//
 	// The AddResource error path at lines 158-159 is defensive programming
 	// for scenarios that are extremely unlikely to occur in practice without
 	// significant changes to the code structure (e.g., reusing compiler instances).

--- a/internal/provider/data_source_jsonschema_validator.go
+++ b/internal/provider/data_source_jsonschema_validator.go
@@ -8,11 +8,10 @@ import (
 	"path/filepath"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	validator "github.com/iilei/terraform-provider-jsonschema/pkg/jsonschema"
 	"github.com/santhosh-tekuri/jsonschema/v6"
+
+	validator "github.com/iilei/terraform-provider-jsonschema/pkg/jsonschema"
 )
-
-
 
 func dataSourceJsonschemaValidator() *schema.Resource {
 	return &schema.Resource{
@@ -71,7 +70,7 @@ func dataSourceJsonschemaValidatorRead(d *schema.ResourceData, m interface{}) er
 	schemaPath := d.Get("schema").(string)
 	schemaVersionOverride := d.Get("schema_version").(string)
 	errorMessageTemplate := d.Get("error_message_template").(string)
-	
+
 	// Use provider default if no template specified
 	if errorMessageTemplate == "" {
 		errorMessageTemplate = config.DefaultErrorTemplate
@@ -82,7 +81,7 @@ func dataSourceJsonschemaValidatorRead(d *schema.ResourceData, m interface{}) er
 	if docFileType == "" {
 		docFileType = validator.FileTypeAuto
 	}
-	
+
 	documentData, err := validator.ParseFile(documentPath, docFileType)
 	if err != nil {
 		return fmt.Errorf("failed to parse document file %q: %w", documentPath, err)
@@ -96,12 +95,12 @@ func dataSourceJsonschemaValidatorRead(d *schema.ResourceData, m interface{}) er
 
 	// Create a new compiler instance for this validation
 	compiler := jsonschema.NewCompiler()
-	
+
 	// Enable JSON5 support for $ref loading
 	compiler.UseLoader(jsonschema.SchemeURLLoader{
 		"file": validator.JSON5FileLoader{},
 	})
-	
+
 	// Determine which schema version to use
 	effectiveSchemaVersion := config.DefaultSchemaVersion
 	if schemaVersionOverride != "" {
@@ -139,22 +138,22 @@ func dataSourceJsonschemaValidatorRead(d *schema.ResourceData, m interface{}) er
 	// - Air-gapped environments (no internet access required)
 	if refOverridesRaw, ok := d.GetOk("ref_overrides"); ok {
 		refOverrides := refOverridesRaw.(map[string]interface{})
-		
+
 		for remoteURL, localPathRaw := range refOverrides {
 			localPath := localPathRaw.(string)
-			
+
 			// Parse the override schema file (supports JSON, JSON5, YAML, TOML - auto-detect)
 			overrideData, err := validator.ParseFile(localPath, validator.FileTypeAuto)
 			if err != nil {
-				return fmt.Errorf("ref_override: failed to parse local file %q for URL %q: %w", 
+				return fmt.Errorf("ref_override: failed to parse local file %q for URL %q: %w",
 					localPath, remoteURL, err)
 			}
-			
+
 			// Pre-register this schema at the remote URL.
 			// When the compiler encounters "$ref": "remoteURL" during schema compilation,
 			// it will use this pre-registered data instead of attempting to load from the URL.
 			if err := compiler.AddResource(remoteURL, overrideData); err != nil {
-				return fmt.Errorf("ref_override: failed to register %q -> %q: %w", 
+				return fmt.Errorf("ref_override: failed to register %q -> %q: %w",
 					remoteURL, localPath, err)
 			}
 		}
@@ -176,14 +175,14 @@ func dataSourceJsonschemaValidatorRead(d *schema.ResourceData, m interface{}) er
 
 	// Add schema resource and compile (v6 API)
 	var parsedSchemaData interface{}
-	if err := json.Unmarshal([]byte(schemaJSON), &parsedSchemaData); err != nil {
+	if err := json.Unmarshal(schemaJSON, &parsedSchemaData); err != nil {
 		return fmt.Errorf("failed to parse schema JSON: %w", err)
 	}
-	
+
 	if err := compiler.AddResource(schemaURL, parsedSchemaData); err != nil {
 		return fmt.Errorf("failed to add schema resource: %w", err)
 	}
-	
+
 	compiledSchema, err := compiler.Compile(schemaURL)
 	if err != nil {
 		return fmt.Errorf("failed to compile schema: %w", err)
@@ -207,10 +206,10 @@ func dataSourceJsonschemaValidatorRead(d *schema.ResourceData, m interface{}) er
 
 	// Generate ID based on document, schema, and configuration
 	// schemaJSON is already available from earlier in the function
-	
-	compositeString := fmt.Sprintf("%s:%s:%s", 
-		string(canonicalJSON), 
-		string(schemaJSON), 
+
+	compositeString := fmt.Sprintf("%s:%s:%s",
+		string(canonicalJSON),
+		string(schemaJSON),
 		effectiveSchemaVersion,
 	)
 	d.SetId(hash(compositeString))

--- a/internal/provider/data_source_jsonschema_validator_test.go
+++ b/internal/provider/data_source_jsonschema_validator_test.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -13,7 +12,7 @@ import (
 
 func Test_dataSourceJsonschemaValidatorRead(t *testing.T) {
 	// Create temporary directory for test schema files
-	tempDir, err := ioutil.TempDir("", "jsonschema_test")
+	tempDir, err := os.MkdirTemp("", "jsonschema_test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -21,60 +20,60 @@ func Test_dataSourceJsonschemaValidatorRead(t *testing.T) {
 
 	// Write schema files
 	schemaFile := filepath.Join(tempDir, "test.schema.json")
-	if err := ioutil.WriteFile(schemaFile, []byte(schemaValid), 0644); err != nil {
+	if err := os.WriteFile(schemaFile, []byte(schemaValid), 0644); err != nil {
 		t.Fatal(err)
 	}
 
 	json5SchemaFile := filepath.Join(tempDir, "test.schema.json5")
-	if err := ioutil.WriteFile(json5SchemaFile, []byte(schemaJSON5), 0644); err != nil {
+	if err := os.WriteFile(json5SchemaFile, []byte(schemaJSON5), 0644); err != nil {
 		t.Fatal(err)
 	}
 
 	var cases = []struct {
-		name          string
-		documentContent string
+		name             string
+		documentContent  string
 		documentFileName string
-		schemaFile    string
-		errorExpected bool
-		expectedJSON  string
+		schemaFile       string
+		errorExpected    bool
+		expectedJSON     string
 	}{
 		{
-			name:          "invalid document",
-			documentContent: "asd asdasd: ^%^*&^%",
+			name:             "invalid document",
+			documentContent:  "asd asdasd: ^%^*&^%",
 			documentFileName: "invalid.txt",
-			schemaFile:    schemaFile,
-			errorExpected: true,
+			schemaFile:       schemaFile,
+			errorExpected:    true,
 		},
 		{
-			name:          "empty object fails required validation",
-			documentContent: "{}",
+			name:             "empty object fails required validation",
+			documentContent:  "{}",
 			documentFileName: "empty.json",
-			schemaFile:    schemaFile,
-			errorExpected: true,
+			schemaFile:       schemaFile,
+			errorExpected:    true,
 		},
 		{
-			name:          "valid document",
-			documentContent: `{"test": "test"}`,
+			name:             "valid document",
+			documentContent:  `{"test": "test"}`,
 			documentFileName: "valid.json",
-			schemaFile:    schemaFile,
-			errorExpected: false,
-			expectedJSON:  `{"test":"test"}`,
+			schemaFile:       schemaFile,
+			errorExpected:    false,
+			expectedJSON:     `{"test":"test"}`,
 		},
 		{
-			name:          "JSON5 document with comments",
-			documentContent: `{"test": "test", /* comment */ }`,
+			name:             "JSON5 document with comments",
+			documentContent:  `{"test": "test", /* comment */ }`,
 			documentFileName: "valid.json5",
-			schemaFile:    schemaFile,
-			errorExpected: false,
-			expectedJSON:  `{"test":"test"}`,
+			schemaFile:       schemaFile,
+			errorExpected:    false,
+			expectedJSON:     `{"test":"test"}`,
 		},
 		{
-			name:          "JSON5 schema with JSON document",
-			documentContent: `{"name": "example", "age": 25}`,
+			name:             "JSON5 schema with JSON document",
+			documentContent:  `{"name": "example", "age": 25}`,
 			documentFileName: "person.json",
-			schemaFile:    json5SchemaFile,
-			errorExpected: false,
-			expectedJSON:  `{"age":25,"name":"example"}`,
+			schemaFile:       json5SchemaFile,
+			errorExpected:    false,
+			expectedJSON:     `{"age":25,"name":"example"}`,
 		},
 	}
 
@@ -82,7 +81,7 @@ func Test_dataSourceJsonschemaValidatorRead(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// Create document file
 			docFile := filepath.Join(tempDir, tt.documentFileName)
-			if err := ioutil.WriteFile(docFile, []byte(tt.documentContent), 0644); err != nil {
+			if err := os.WriteFile(docFile, []byte(tt.documentContent), 0644); err != nil {
 				t.Fatal(err)
 			}
 
@@ -118,20 +117,20 @@ func Test_dataSourceJsonschemaValidatorRead(t *testing.T) {
 
 func TestProviderConfiguration(t *testing.T) {
 	// Create temporary directory for test schema files
-	tempDir, err := ioutil.TempDir("", "jsonschema_test")
+	tempDir, err := os.MkdirTemp("", "jsonschema_test")
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer os.RemoveAll(tempDir)
 
 	schemaFile := filepath.Join(tempDir, "test.schema.json")
-	if err := ioutil.WriteFile(schemaFile, []byte(schemaValidDraft04), 0644); err != nil {
+	if err := os.WriteFile(schemaFile, []byte(schemaValidDraft04), 0644); err != nil {
 		t.Fatal(err)
 	}
 
 	// Create document file
 	docFile := filepath.Join(tempDir, "test.json")
-	if err := ioutil.WriteFile(docFile, []byte(`{"test":"value"}`), 0644); err != nil {
+	if err := os.WriteFile(docFile, []byte(`{"test":"value"}`), 0644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -153,7 +152,7 @@ func TestProviderConfiguration(t *testing.T) {
 // This is a breaking change from the previous implementation that hardcoded "schema.json" in the URL
 func TestMultipleSchemasInSameDirectory(t *testing.T) {
 	// Create temporary directory for test schema files
-	tempDir, err := ioutil.TempDir("", "jsonschema_test")
+	tempDir, err := os.MkdirTemp("", "jsonschema_test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -161,52 +160,52 @@ func TestMultipleSchemasInSameDirectory(t *testing.T) {
 
 	// Create multiple schema files in the same directory with different names
 	schema1File := filepath.Join(tempDir, "user.schema.json")
-	if err := ioutil.WriteFile(schema1File, []byte(userSchema), 0644); err != nil {
+	if err := os.WriteFile(schema1File, []byte(userSchema), 0644); err != nil {
 		t.Fatal(err)
 	}
 
 	schema2File := filepath.Join(tempDir, "product.schema.json")
-	if err := ioutil.WriteFile(schema2File, []byte(productSchema), 0644); err != nil {
+	if err := os.WriteFile(schema2File, []byte(productSchema), 0644); err != nil {
 		t.Fatal(err)
 	}
 
 	var cases = []struct {
-		name          string
-		documentContent string
+		name             string
+		documentContent  string
 		documentFileName string
-		schemaFile    string
-		errorExpected bool
-		expectedJSON  string
+		schemaFile       string
+		errorExpected    bool
+		expectedJSON     string
 	}{
 		{
-			name:          "validate user document",
-			documentContent: `{"name": "John", "email": "john@example.com"}`,
+			name:             "validate user document",
+			documentContent:  `{"name": "John", "email": "john@example.com"}`,
 			documentFileName: "user.json",
-			schemaFile:    schema1File,
-			errorExpected: false,
-			expectedJSON:  `{"email":"john@example.com","name":"John"}`,
+			schemaFile:       schema1File,
+			errorExpected:    false,
+			expectedJSON:     `{"email":"john@example.com","name":"John"}`,
 		},
 		{
-			name:          "validate product document",
-			documentContent: `{"sku": "ABC123", "price": 99.99}`,
+			name:             "validate product document",
+			documentContent:  `{"sku": "ABC123", "price": 99.99}`,
 			documentFileName: "product.json",
-			schemaFile:    schema2File,
-			errorExpected: false,
-			expectedJSON:  `{"price":99.99,"sku":"ABC123"}`,
+			schemaFile:       schema2File,
+			errorExpected:    false,
+			expectedJSON:     `{"price":99.99,"sku":"ABC123"}`,
 		},
 		{
-			name:          "invalid user document against user schema",
-			documentContent: `{"name": "John"}`, // missing email
+			name:             "invalid user document against user schema",
+			documentContent:  `{"name": "John"}`, // missing email
 			documentFileName: "invalid_user.json",
-			schemaFile:    schema1File,
-			errorExpected: true,
+			schemaFile:       schema1File,
+			errorExpected:    true,
 		},
 		{
-			name:          "invalid product document against product schema",
-			documentContent: `{"sku": "ABC123"}`, // missing price
+			name:             "invalid product document against product schema",
+			documentContent:  `{"sku": "ABC123"}`, // missing price
 			documentFileName: "invalid_product.json",
-			schemaFile:    schema2File,
-			errorExpected: true,
+			schemaFile:       schema2File,
+			errorExpected:    true,
 		},
 	}
 
@@ -214,7 +213,7 @@ func TestMultipleSchemasInSameDirectory(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// Create document file
 			docFile := filepath.Join(tempDir, tt.documentFileName)
-			if err := ioutil.WriteFile(docFile, []byte(tt.documentContent), 0644); err != nil {
+			if err := os.WriteFile(docFile, []byte(tt.documentContent), 0644); err != nil {
 				t.Fatal(err)
 			}
 
@@ -339,7 +338,7 @@ var productSchema = `{
 
 func TestRefOverrides(t *testing.T) {
 	// Create temporary directory for test schemas
-	tempDir, err := ioutil.TempDir("", "jsonschema_ref_override_test")
+	tempDir, err := os.MkdirTemp("", "jsonschema_ref_override_test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -394,17 +393,17 @@ func TestRefOverrides(t *testing.T) {
 
 	// Write schema files
 	mainSchemaPath := filepath.Join(tempDir, "main.schema.json")
-	if err := ioutil.WriteFile(mainSchemaPath, []byte(mainSchema), 0644); err != nil {
+	if err := os.WriteFile(mainSchemaPath, []byte(mainSchema), 0644); err != nil {
 		t.Fatal(err)
 	}
 
 	userSchemaPath := filepath.Join(tempDir, "user.schema.json")
-	if err := ioutil.WriteFile(userSchemaPath, []byte(userSchema), 0644); err != nil {
+	if err := os.WriteFile(userSchemaPath, []byte(userSchema), 0644); err != nil {
 		t.Fatal(err)
 	}
 
 	productSchemaPath := filepath.Join(tempDir, "product.schema.json")
-	if err := ioutil.WriteFile(productSchemaPath, []byte(productSchema), 0644); err != nil {
+	if err := os.WriteFile(productSchemaPath, []byte(productSchema), 0644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -422,7 +421,7 @@ func TestRefOverrides(t *testing.T) {
 
 	// Write test document file
 	testDocPath := filepath.Join(tempDir, "test.json")
-	if err := ioutil.WriteFile(testDocPath, []byte(testDoc), 0644); err != nil {
+	if err := os.WriteFile(testDocPath, []byte(testDoc), 0644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -468,7 +467,7 @@ func TestRefOverridesErrors(t *testing.T) {
 	}
 
 	t.Run("missing override file", func(t *testing.T) {
-		tempDir, err := ioutil.TempDir("", "jsonschema_ref_override_error_test")
+		tempDir, err := os.MkdirTemp("", "jsonschema_ref_override_error_test")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -477,13 +476,13 @@ func TestRefOverridesErrors(t *testing.T) {
 		// Create a simple schema
 		mainSchema := `{"type": "object"}`
 		mainSchemaPath := filepath.Join(tempDir, "main.schema.json")
-		if err := ioutil.WriteFile(mainSchemaPath, []byte(mainSchema), 0644); err != nil {
+		if err := os.WriteFile(mainSchemaPath, []byte(mainSchema), 0644); err != nil {
 			t.Fatal(err)
 		}
 
 		// Create document file
 		docPath := filepath.Join(tempDir, "test.json")
-		if err := ioutil.WriteFile(docPath, []byte(`{}`), 0644); err != nil {
+		if err := os.WriteFile(docPath, []byte(`{}`), 0644); err != nil {
 			t.Fatal(err)
 		}
 
@@ -504,7 +503,7 @@ func TestRefOverridesErrors(t *testing.T) {
 	})
 
 	t.Run("invalid JSON in override file", func(t *testing.T) {
-		tempDir, err := ioutil.TempDir("", "jsonschema_ref_override_error_test")
+		tempDir, err := os.MkdirTemp("", "jsonschema_ref_override_error_test")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -513,19 +512,19 @@ func TestRefOverridesErrors(t *testing.T) {
 		// Create a simple schema
 		mainSchema := `{"type": "object"}`
 		mainSchemaPath := filepath.Join(tempDir, "main.schema.json")
-		if err := ioutil.WriteFile(mainSchemaPath, []byte(mainSchema), 0644); err != nil {
+		if err := os.WriteFile(mainSchemaPath, []byte(mainSchema), 0644); err != nil {
 			t.Fatal(err)
 		}
 
 		// Create invalid override file
 		invalidOverride := filepath.Join(tempDir, "invalid.json")
-		if err := ioutil.WriteFile(invalidOverride, []byte(`{invalid json`), 0644); err != nil {
+		if err := os.WriteFile(invalidOverride, []byte(`{invalid json`), 0644); err != nil {
 			t.Fatal(err)
 		}
 
 		// Create document file
 		docPath := filepath.Join(tempDir, "test.json")
-		if err := ioutil.WriteFile(docPath, []byte(`{}`), 0644); err != nil {
+		if err := os.WriteFile(docPath, []byte(`{}`), 0644); err != nil {
 			t.Fatal(err)
 		}
 
@@ -545,4 +544,3 @@ func TestRefOverridesErrors(t *testing.T) {
 		}
 	})
 }
-

--- a/internal/provider/data_source_unit_test.go
+++ b/internal/provider/data_source_unit_test.go
@@ -58,16 +58,16 @@ func TestDataSourceJsonschemaValidatorRead(t *testing.T) {
 	}
 
 	tests := []struct {
-		name                   string
-		documentContent        string
-		documentFileName       string
-		schemaFile             string
-		schemaVersionOverride  string
-		errorMessageTemplate   string
-		providerConfig         *ProviderConfig
-		expectError            bool
-		errorContains          string
-		expectedValidJson      string
+		name                  string
+		documentContent       string
+		documentFileName      string
+		schemaFile            string
+		schemaVersionOverride string
+		errorMessageTemplate  string
+		providerConfig        *ProviderConfig
+		expectError           bool
+		errorContains         string
+		expectedValidJson     string
 	}{
 		{
 			name:             "valid document validation",
@@ -233,11 +233,11 @@ func TestDataSourceJsonschemaValidatorRead_InvalidProviderConfig(t *testing.T) {
 
 	// Pass invalid config type
 	err = dataSourceJsonschemaValidatorRead(resourceData, "invalid-config")
-	
+
 	if err == nil {
 		t.Errorf("expected error for invalid provider config")
 	}
-	
+
 	if !strings.Contains(err.Error(), "invalid provider configuration") {
 		t.Errorf("expected specific error message, got: %v", err)
 	}
@@ -273,7 +273,7 @@ func TestDataSourceJsonschemaValidatorRead_InvalidDocumentParsing(t *testing.T) 
 	}
 
 	err = dataSourceJsonschemaValidatorRead(resourceData, config)
-	
+
 	if err == nil || !strings.Contains(err.Error(), "failed to parse document") {
 		t.Errorf("expected 'failed to parse document' error, got: %v", err)
 	}
@@ -310,11 +310,11 @@ func TestDataSourceJsonschemaValidatorRead_InvalidSchemaVersion(t *testing.T) {
 	}
 
 	err = dataSourceJsonschemaValidatorRead(resourceData, config)
-	
+
 	if err == nil {
 		t.Errorf("expected error for invalid schema version")
 	}
-	
+
 	if !strings.Contains(err.Error(), "unsupported JSON Schema version") {
 		t.Errorf("expected specific error message, got: %v", err)
 	}
@@ -343,7 +343,7 @@ func TestDataSourceJsonschemaValidatorRead_MissingSchemaFile(t *testing.T) {
 	}
 
 	err = dataSourceJsonschemaValidatorRead(resourceData, config)
-	
+
 	if err == nil || !strings.Contains(err.Error(), "failed to parse schema file") {
 		t.Errorf("expected 'failed to parse schema file' error, got: %v", err)
 	}
@@ -378,7 +378,7 @@ func TestDataSourceJsonschemaValidatorRead_UnreadableSchemaFile(t *testing.T) {
 	}
 
 	err = dataSourceJsonschemaValidatorRead(resourceData, config)
-	
+
 	if err == nil || !strings.Contains(err.Error(), "failed to parse schema file") {
 		t.Errorf("expected 'failed to parse schema file' error, got: %v", err)
 	}
@@ -413,7 +413,7 @@ func TestDataSourceJsonschemaValidatorRead_InvalidSchemaFile(t *testing.T) {
 	}
 
 	err = dataSourceJsonschemaValidatorRead(resourceData, config)
-	
+
 	if err == nil || !strings.Contains(err.Error(), "failed to parse schema file") {
 		t.Errorf("expected 'failed to parse schema file' error, got: %v", err)
 	}
@@ -592,14 +592,14 @@ func TestDataSourceJsonschemaValidatorRead_RefOverrides(t *testing.T) {
 	}
 
 	tests := []struct {
-		name          string
+		name            string
 		documentContent string
-		refOverrides  map[string]interface{}
-		expectError   bool
-		errorContains string
+		refOverrides    map[string]interface{}
+		expectError     bool
+		errorContains   string
 	}{
 		{
-			name:     "valid ref override",
+			name:            "valid ref override",
 			documentContent: `{"user": {"name": "John", "email": "john@example.com"}}`,
 			refOverrides: map[string]interface{}{
 				"https://example.com/schemas/user.json": overrideSchemaFile,
@@ -607,7 +607,7 @@ func TestDataSourceJsonschemaValidatorRead_RefOverrides(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name:     "validation fails with override",
+			name:            "validation fails with override",
 			documentContent: `{"user": {"email": "john@example.com"}}`, // missing required "name"
 			refOverrides: map[string]interface{}{
 				"https://example.com/schemas/user.json": overrideSchemaFile,
@@ -616,7 +616,7 @@ func TestDataSourceJsonschemaValidatorRead_RefOverrides(t *testing.T) {
 			errorContains: "validation",
 		},
 		{
-			name:     "missing override file",
+			name:            "missing override file",
 			documentContent: `{"user": {"name": "John"}}`,
 			refOverrides: map[string]interface{}{
 				"https://example.com/schemas/user.json": "/nonexistent/file.json",
@@ -625,7 +625,7 @@ func TestDataSourceJsonschemaValidatorRead_RefOverrides(t *testing.T) {
 			errorContains: "ref_override: failed to parse local file",
 		},
 		{
-			name:     "invalid override file syntax",
+			name:            "invalid override file syntax",
 			documentContent: `{"user": {"name": "John"}}`,
 			refOverrides: map[string]interface{}{
 				"https://example.com/schemas/user.json": invalidOverrideFile,
@@ -634,7 +634,7 @@ func TestDataSourceJsonschemaValidatorRead_RefOverrides(t *testing.T) {
 			errorContains: "ref_override: failed to parse local file",
 		},
 		{
-			name:     "unreadable override file",
+			name:            "unreadable override file",
 			documentContent: `{"user": {"name": "John"}}`,
 			refOverrides: map[string]interface{}{
 				"https://example.com/schemas/user.json": unreadableOverrideFile,
@@ -643,7 +643,7 @@ func TestDataSourceJsonschemaValidatorRead_RefOverrides(t *testing.T) {
 			errorContains: "ref_override: failed to parse local file",
 		},
 		{
-			name:     "invalid schema structure in override",
+			name:            "invalid schema structure in override",
 			documentContent: `{"user": {"name": "John"}}`,
 			refOverrides: map[string]interface{}{
 				"https://example.com/schemas/user.json": invalidSchemaOverrideFile,
@@ -723,18 +723,18 @@ func TestDataSourceJsonschemaValidatorRead_SchemaCompilationErrors(t *testing.T)
 	}
 
 	tests := []struct {
-		name          string
-		schemaFile    string
+		name            string
+		schemaFile      string
 		documentContent string
-		expectError   bool
-		errorContains string
+		expectError     bool
+		errorContains   string
 	}{
 		{
-			name:          "invalid type in schema",
-			schemaFile:    invalidSchemaFile,
+			name:            "invalid type in schema",
+			schemaFile:      invalidSchemaFile,
 			documentContent: `{"name": "test"}`,
-			expectError:   true,
-			errorContains: "failed to compile schema",
+			expectError:     true,
+			errorContains:   "failed to compile schema",
 		},
 	}
 

--- a/internal/provider/data_source_validation_test.go
+++ b/internal/provider/data_source_validation_test.go
@@ -1,8 +1,9 @@
 package provider
 
 import (
-validator "github.com/iilei/terraform-provider-jsonschema/pkg/jsonschema"
 	"testing"
+
+	validator "github.com/iilei/terraform-provider-jsonschema/pkg/jsonschema"
 )
 
 func TestDataSourceValidationLogic(t *testing.T) {
@@ -15,10 +16,10 @@ func TestDataSourceValidationLogic(t *testing.T) {
 		expectedResult string
 	}{
 		{
-			name:           "valid config creation",
-			document:       `{"test": "value"}`,
-			schemaVersion:  "draft-07",
-			expectError:    false,
+			name:          "valid config creation",
+			document:      `{"test": "value"}`,
+			schemaVersion: "draft-07",
+			expectError:   false,
 		},
 		{
 			name:          "invalid schema version",
@@ -27,9 +28,9 @@ func TestDataSourceValidationLogic(t *testing.T) {
 			expectError:   true,
 		},
 		{
-			name:        "JSON5 document parsing",
-			document:    `{test: "value", /* comment */}`,
-			expectError: false,
+			name:           "JSON5 document parsing",
+			document:       `{test: "value", /* comment */}`,
+			expectError:    false,
 			expectedResult: `{"test":"value"}`,
 		},
 		{
@@ -80,10 +81,10 @@ func TestDataSourceValidationLogic(t *testing.T) {
 
 func TestDataSourceSchemaStructure(t *testing.T) {
 	ds := dataSourceJsonschemaValidator()
-	
+
 	// Test that all required fields are present in the schema
 	expectedFields := []string{"document", "schema", "schema_version", "error_message_template"}
-	
+
 	for _, field := range expectedFields {
 		if _, ok := ds.Schema[field]; !ok {
 			t.Errorf("expected field %q to be present in data source schema", field)
@@ -104,13 +105,13 @@ func TestDataSourceSchemaStructure(t *testing.T) {
 // Mock helper for testing configuration combinations
 func TestConfigurationOverrides(t *testing.T) {
 	tests := []struct {
-		name                    string
-		providerSchemaVersion   string
-		providerErrorTemplate   string
-		resourceSchemaVersion   string
-		resourceErrorTemplate   string
-		expectedSchemaVersion   string
-		expectedErrorTemplate   string
+		name                  string
+		providerSchemaVersion string
+		providerErrorTemplate string
+		resourceSchemaVersion string
+		resourceErrorTemplate string
+		expectedSchemaVersion string
+		expectedErrorTemplate string
 	}{
 		{
 			name:                  "provider defaults only",
@@ -148,10 +149,7 @@ func TestConfigurationOverrides(t *testing.T) {
 			}
 
 			// Simulate resource-level overrides
-			finalSchemaVersion := tt.resourceSchemaVersion
-			if finalSchemaVersion == "" {
-				finalSchemaVersion = providerConfig.DefaultSchemaVersion
-			}
+			_ = tt.resourceSchemaVersion // Used for test structure only
 
 			finalErrorTemplate := tt.resourceErrorTemplate
 			if finalErrorTemplate == "" {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -27,7 +27,6 @@ func New(version string) func() *schema.Provider {
 					Default:     "{{.FullMessage}}",
 					Description: "Default error message template for validation failures. Can be overridden per data source. Available variables: {{.SchemaFile}}, {{.Document}}, {{.FullMessage}}, {{.Errors}}, {{.ErrorCount}}. Use {{range .Errors}} to iterate over individual errors.",
 				},
-
 			},
 			DataSourcesMap: map[string]*schema.Resource{
 				"jsonschema_validator": dataSourceJsonschemaValidator(),

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -90,7 +91,7 @@ func TestProviderConfigureFunction(t *testing.T) {
 		{
 			name: "valid configuration with all fields",
 			configData: map[string]interface{}{
-				"schema_version":        "draft-07",
+				"schema_version":         "draft-07",
 				"error_message_template": "Error in {schema}: {error}",
 			},
 			expectError: false,
@@ -98,7 +99,7 @@ func TestProviderConfigureFunction(t *testing.T) {
 		{
 			name: "valid configuration with defaults",
 			configData: map[string]interface{}{
-				"schema_version":        "draft/2020-12",
+				"schema_version":         "draft/2020-12",
 				"error_message_template": "{{range .Errors}}{{.Message}}{{end}}",
 			},
 			expectError: false,
@@ -106,7 +107,7 @@ func TestProviderConfigureFunction(t *testing.T) {
 		{
 			name: "invalid schema version",
 			configData: map[string]interface{}{
-				"schema_version":        "invalid-draft",
+				"schema_version":         "invalid-draft",
 				"error_message_template": "",
 			},
 			expectError:   true,
@@ -115,7 +116,7 @@ func TestProviderConfigureFunction(t *testing.T) {
 		{
 			name: "empty configuration (should use defaults)",
 			configData: map[string]interface{}{
-				"schema_version":        "",
+				"schema_version":         "",
 				"error_message_template": "",
 			},
 			expectError: false,
@@ -129,7 +130,7 @@ func TestProviderConfigureFunction(t *testing.T) {
 			resourceData := schema.TestResourceDataRaw(t, provider.Schema, tt.configData)
 
 			// Call providerConfigure
-			result, diags := providerConfigure(nil, resourceData)
+			result, diags := providerConfigure(context.Background(), resourceData)
 
 			if tt.expectError {
 				if !diags.HasError() {
@@ -172,7 +173,7 @@ func TestProviderConfigureFunction(t *testing.T) {
 			expectedSchemaVersion := tt.configData["schema_version"].(string)
 			// When schema_version is empty, it's stored as-is (empty string) in DefaultSchemaVersion
 			// The default draft is set to Draft2020 in the DefaultDraft field instead
-			
+
 			if config.DefaultSchemaVersion != expectedSchemaVersion {
 				t.Errorf("expected schema version %q, got %q", expectedSchemaVersion, config.DefaultSchemaVersion)
 			}
@@ -193,7 +194,7 @@ func TestProviderSchemaDefinition(t *testing.T) {
 
 	// Test that all expected schema fields exist
 	expectedFields := []string{"schema_version", "error_message_template"}
-	
+
 	for _, field := range expectedFields {
 		if _, exists := provider.Schema[field]; !exists {
 			t.Errorf("expected schema field %q not found", field)

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
+
 	"github.com/iilei/terraform-provider-jsonschema/internal/provider"
 )
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -119,20 +119,20 @@ func (s *SchemaConfig) GetEffectiveForceFiletype(flagValue string) string {
 // Later sources override earlier ones (command-line > config file > defaults)
 func MergeRefOverrides(sources ...map[string]string) map[string]string {
 	result := make(map[string]string)
-	
+
 	for _, source := range sources {
 		for key, value := range source {
 			result[key] = value
 		}
 	}
-	
+
 	return result
 }
 
 // ExpandDocumentGlobs expands glob patterns in document paths
 func (s *SchemaConfig) ExpandDocumentGlobs() ([]string, error) {
 	var expanded []string
-	
+
 	for _, pattern := range s.Documents {
 		// Check if pattern contains glob characters
 		if !containsGlobChars(pattern) {
@@ -140,22 +140,22 @@ func (s *SchemaConfig) ExpandDocumentGlobs() ([]string, error) {
 			expanded = append(expanded, pattern)
 			continue
 		}
-		
+
 		// Expand glob pattern
 		matches, err := filepath.Glob(pattern)
 		if err != nil {
 			return nil, fmt.Errorf("invalid glob pattern %q: %w", pattern, err)
 		}
-		
+
 		if len(matches) == 0 {
 			// No matches found - this might be intentional (e.g., no files yet)
 			// Don't treat as error, just skip
 			continue
 		}
-		
+
 		expanded = append(expanded, matches...)
 	}
-	
+
 	return expanded, nil
 }
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -191,10 +191,10 @@ func TestSchemaConfig_GetEffectiveErrorTemplate(t *testing.T) {
 
 func TestSchemaConfig_GetEffectiveForceFiletype(t *testing.T) {
 	tests := []struct {
-		name              string
-		configForceType   string
-		flagForceType     string
-		want              string
+		name            string
+		configForceType string
+		flagForceType   string
+		want            string
 	}{
 		{
 			name:            "flag takes precedence",
@@ -332,7 +332,7 @@ func TestSchemaConfig_ExpandDocumentGlobs(t *testing.T) {
 			wantErr:   false,
 		},
 		{
-			name:      "mixed glob and non-glob",
+			name: "mixed glob and non-glob",
 			documents: []string{
 				filepath.Join(tempDir, "data.json"),
 				filepath.Join(tempDir, "config.*.json"),

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -190,8 +190,9 @@ func (l *Loader) loadPyprojectTOML() error {
 // Environment variables use SCREAMING_SNAKE_CASE (no camelCase!)
 // Prefixed with the configured prefix (default: JSONSCHEMA_VALIDATOR_)
 // Examples (with default prefix):
-//   JSONSCHEMA_VALIDATOR_SCHEMA_VERSION=draft/2020-12
-//   JSONSCHEMA_VALIDATOR_ERROR_TEMPLATE="..."
+//
+//	JSONSCHEMA_VALIDATOR_SCHEMA_VERSION=draft/2020-12
+//	JSONSCHEMA_VALIDATOR_ERROR_TEMPLATE="..."
 func (l *Loader) loadEnvVars() error {
 	return l.k.Load(env.Provider(l.envPrefix, ".", func(s string) string {
 		// Convert JSONSCHEMA_VALIDATOR_SCHEMA_VERSION to schema_version

--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -256,7 +256,7 @@ func TestLoader_CustomEnvPrefix(t *testing.T) {
 
 	loader := NewLoader()
 	loader.SetEnvPrefix("MY_APP_")
-	
+
 	cfg, err := loader.Load(nil)
 	if err != nil {
 		t.Fatalf("Load() failed: %v", err)
@@ -265,23 +265,23 @@ func TestLoader_CustomEnvPrefix(t *testing.T) {
 	if cfg.SchemaVersion != "draft/2020-12" {
 		t.Errorf("schema_version = %q, want %q", cfg.SchemaVersion, "draft/2020-12")
 	}
-	
+
 	if cfg.ErrorTemplate != "Custom: {{.FullMessage}}" {
 		t.Errorf("error_template = %q, want %q", cfg.ErrorTemplate, "Custom: {{.FullMessage}}")
 	}
-	
+
 	// Verify default prefix doesn't work
 	os.Setenv("JSONSCHEMA_VALIDATOR_SCHEMA_VERSION", "draft/2019-09")
 	defer os.Unsetenv("JSONSCHEMA_VALIDATOR_SCHEMA_VERSION")
-	
+
 	loader2 := NewLoader()
 	loader2.SetEnvPrefix("MY_APP_")
-	
+
 	cfg2, err := loader2.Load(nil)
 	if err != nil {
 		t.Fatalf("Load() failed: %v", err)
 	}
-	
+
 	// Should still use MY_APP_ prefix, not JSONSCHEMA_VALIDATOR_
 	if cfg2.SchemaVersion != "draft/2020-12" {
 		t.Errorf("schema_version = %q, want %q (should ignore JSONSCHEMA_VALIDATOR_ prefix)", cfg2.SchemaVersion, "draft/2020-12")
@@ -295,7 +295,7 @@ func TestLoader_LoadFlags(t *testing.T) {
 	flags.Parse([]string{"--schema.version", "draft/2019-09"})
 
 	loader := NewLoader()
-	
+
 	// Load flags using posflag provider
 	if err := loader.loadFlags(flags); err != nil {
 		t.Fatalf("Load flags failed: %v", err)
@@ -310,7 +310,7 @@ func TestLoader_LoadFlags(t *testing.T) {
 	if *schemaVersion != "draft/2019-09" {
 		t.Errorf("flag value = %q, want %q", *schemaVersion, "draft/2019-09")
 	}
-	
+
 	// Note: Flag to config field mapping happens in CLI main.go
 	// This test verifies the flag loading mechanism works
 }

--- a/pkg/jsonschema/deterministic.go
+++ b/pkg/jsonschema/deterministic.go
@@ -16,33 +16,33 @@ func MarshalDeterministic(data interface{}) ([]byte, error) {
 // sortKeys recursively sorts all map keys in the data structure to ensure deterministic output
 func sortKeys(data interface{}) interface{} {
 	v := reflect.ValueOf(data)
-	
+
 	switch v.Kind() {
 	case reflect.Map:
 		if v.Type().Key().Kind() == reflect.String {
 			// Create a new map with sorted keys
 			sortedMap := make(map[string]interface{})
 			keys := make([]string, 0, v.Len())
-			
+
 			// Collect all keys
 			for _, key := range v.MapKeys() {
 				keys = append(keys, key.String())
 			}
-			
+
 			// Sort keys
 			sort.Strings(keys)
-			
+
 			// Rebuild map with sorted keys and recursively sort values
 			for _, key := range keys {
 				value := v.MapIndex(reflect.ValueOf(key))
 				sortedMap[key] = sortKeys(value.Interface())
 			}
-			
+
 			return sortedMap
 		}
 		// For non-string keyed maps, return as-is (shouldn't happen in JSON)
 		return data
-		
+
 	case reflect.Slice, reflect.Array:
 		// Process each element in the slice/array
 		length := v.Len()
@@ -51,19 +51,19 @@ func sortKeys(data interface{}) interface{} {
 			result[i] = sortKeys(v.Index(i).Interface())
 		}
 		return result
-		
+
 	case reflect.Ptr:
 		if v.IsNil() {
 			return nil
 		}
 		return sortKeys(v.Elem().Interface())
-		
+
 	case reflect.Interface:
 		if v.IsNil() {
 			return nil
 		}
 		return sortKeys(v.Elem().Interface())
-		
+
 	default:
 		// For primitive types (string, int, bool, etc.), return as-is
 		return data
@@ -85,12 +85,12 @@ func CompactDeterministicJSON(data interface{}) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	
+
 	// Compact the JSON to remove unnecessary whitespace
 	var buf bytes.Buffer
 	if err := json.Compact(&buf, jsonBytes); err != nil {
 		return nil, fmt.Errorf("failed to compact JSON: %w", err)
 	}
-	
+
 	return buf.Bytes(), nil
 }

--- a/pkg/jsonschema/deterministic_test.go
+++ b/pkg/jsonschema/deterministic_test.go
@@ -1,10 +1,10 @@
 package jsonschema
 
 import (
+	"bytes"
 	"encoding/json"
 	"strings"
 	"testing"
-
 )
 
 func TestMarshalDeterministic(t *testing.T) {
@@ -30,7 +30,7 @@ func TestMarshalDeterministic(t *testing.T) {
 		t.Fatalf("Second marshal failed: %v", err2)
 	}
 
-	if string(result1) != string(result2) {
+	if !bytes.Equal(result1, result2) {
 		t.Errorf("Non-deterministic results:\nFirst:  %s\nSecond: %s", result1, result2)
 	}
 
@@ -235,7 +235,7 @@ func TestMarshalDeterministicStringErrorHandling(t *testing.T) {
 	invalidData := map[string]interface{}{
 		"function": func() {},
 	}
-	
+
 	result, err := MarshalDeterministicString(invalidData)
 	if err == nil {
 		t.Errorf("expected error for invalid data, got result: %s", result)
@@ -251,7 +251,7 @@ func TestCompactDeterministicJSONErrorHandling(t *testing.T) {
 	invalidData := map[string]interface{}{
 		"function": func() {},
 	}
-	
+
 	result, err := CompactDeterministicJSON(invalidData)
 	if err == nil {
 		t.Errorf("expected error for invalid data, got result: %s", result)
@@ -273,7 +273,7 @@ func TestSortKeysReflectionEdgeCases(t *testing.T) {
 			desc:  "Empty map with string keys should be handled correctly",
 		},
 		{
-			name:  "empty_int_keyed_map", 
+			name:  "empty_int_keyed_map",
 			input: map[int]interface{}{},
 			desc:  "Empty map with non-string keys should return as-is",
 		},
@@ -300,7 +300,7 @@ func TestSortKeysReflectionEdgeCases(t *testing.T) {
 			name: "interface_containing_empty_interface",
 			input: func() interface{} {
 				var inner interface{} = nil
-				var outer interface{} = inner
+				var outer = inner
 				return outer
 			}(),
 			desc: "Interface containing nil interface should return nil",
@@ -309,7 +309,7 @@ func TestSortKeysReflectionEdgeCases(t *testing.T) {
 			name: "map_with_complex_key_type",
 			input: map[interface{}]interface{}{
 				"string_key": "value1",
-				42:           "value2", 
+				42:           "value2",
 			},
 			desc: "Map with interface{} keys (non-string) should return as-is",
 		},
@@ -332,7 +332,7 @@ func TestSortKeysReflectionEdgeCases(t *testing.T) {
 				}(),
 				func() interface{} {
 					var p *int = nil
-					return p  
+					return p
 				}(),
 				func() interface{} {
 					i := 42
@@ -392,9 +392,9 @@ func TestSortKeysReflectionEdgeCases(t *testing.T) {
 					t.Errorf("sortKeys panicked on %s: %v", tt.desc, r)
 				}
 			}()
-			
+
 			result := sortKeys(tt.input)
-			
+
 			// Ensure result can be marshaled to JSON (basic validation)
 			_, err := json.Marshal(result)
 			if err != nil {
@@ -403,7 +403,7 @@ func TestSortKeysReflectionEdgeCases(t *testing.T) {
 					t.Errorf("sortKeys result for %s could not be marshaled: %v", tt.desc, err)
 				}
 			}
-			
+
 			// For nil inputs, expect nil output
 			if tt.input == nil && result != nil {
 				t.Errorf("Expected nil result for nil input, got: %v", result)
@@ -436,7 +436,7 @@ func TestSortKeysMapKeyTypeValidation(t *testing.T) {
 			createMap: func() interface{} {
 				return map[int]interface{}{
 					3: "three",
-					1: "one", 
+					1: "one",
 					2: "two",
 				}
 			},
@@ -472,22 +472,22 @@ func TestSortKeysMapKeyTypeValidation(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			input := tt.createMap()
 			result := sortKeys(input)
-			
+
 			// Convert both to JSON to compare
 			inputJSON, _ := json.Marshal(input)
 			resultJSON, _ := json.Marshal(result)
-			
+
 			if tt.shouldSort {
 				// For string-keyed maps, the result should be different (sorted)
 				// We can't easily test exact order without more complex logic,
 				// but we can ensure it's still valid JSON of the same structure
-				if string(inputJSON) == string(resultJSON) {
+				if bytes.Equal(inputJSON, resultJSON) {
 					// This could be OK if the input was already sorted
 					t.Logf("Input was already sorted or result unchanged for %s", tt.description)
 				}
 			} else {
 				// For non-string-keyed maps, result should be identical to input
-				if string(inputJSON) != string(resultJSON) {
+				if !bytes.Equal(inputJSON, resultJSON) {
 					t.Errorf("%s: expected unchanged result, input: %s, result: %s", tt.description, inputJSON, resultJSON)
 				}
 			}
@@ -502,15 +502,15 @@ func TestSortKeysCompleteReflectionCoverage(t *testing.T) {
 		input interface{}
 	}{
 		{
-			name: "empty_map_with_string_keys",
+			name:  "empty_map_with_string_keys",
 			input: make(map[string]interface{}),
 		},
 		{
-			name: "single_key_map",
+			name:  "single_key_map",
 			input: map[string]interface{}{"single": "value"},
 		},
 		{
-			name: "map_with_zero_length_after_filtering",
+			name:  "map_with_zero_length_after_filtering",
 			input: map[string]interface{}{},
 		},
 		{
@@ -534,17 +534,17 @@ func TestSortKeysCompleteReflectionCoverage(t *testing.T) {
 			},
 		},
 		{
-			name: "array_with_nil_elements",
+			name:  "array_with_nil_elements",
 			input: [3]interface{}{nil, nil, nil},
 		},
 		{
 			name: "map_value_type_edge_cases",
 			input: map[string]interface{}{
-				"nil_value":       nil,
-				"pointer_to_nil":  (*string)(nil),
-				"empty_slice":     []interface{}{},
-				"nil_slice":       []interface{}(nil),
-				"empty_map":       map[string]interface{}{},
+				"nil_value":      nil,
+				"pointer_to_nil": (*string)(nil),
+				"empty_slice":    []interface{}{},
+				"nil_slice":      []interface{}(nil),
+				"empty_map":      map[string]interface{}{},
 			},
 		},
 	}
@@ -559,7 +559,7 @@ func TestSortKeysCompleteReflectionCoverage(t *testing.T) {
 			}()
 
 			result := sortKeys(tt.input)
-			
+
 			// Verify the result is JSON-serializable (basic validation)
 			if result != nil {
 				_, err := json.Marshal(result)
@@ -623,19 +623,19 @@ func TestSortKeysInterfaceHandling(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := sortKeys(tt.input)
-			
+
 			// Marshal both to JSON for comparison
 			expectedJSON, err1 := json.Marshal(tt.expected)
 			resultJSON, err2 := json.Marshal(result)
-			
+
 			if err1 != nil {
 				t.Fatalf("Failed to marshal expected: %v", err1)
 			}
 			if err2 != nil {
 				t.Fatalf("Failed to marshal result: %v", err2)
 			}
-			
-			if string(expectedJSON) != string(resultJSON) {
+
+			if !bytes.Equal(expectedJSON, resultJSON) {
 				t.Errorf("Expected %s, got %s", string(expectedJSON), string(resultJSON))
 			}
 		})
@@ -690,7 +690,7 @@ func TestMarshalDeterministicComplexNesting(t *testing.T) {
 			if err != nil {
 				t.Errorf("MarshalDeterministic failed: %v", err)
 			}
-			
+
 			// Verify result is valid JSON
 			var unmarshaled interface{}
 			if err := json.Unmarshal(result, &unmarshaled); err != nil {
@@ -703,12 +703,12 @@ func TestMarshalDeterministicComplexNesting(t *testing.T) {
 func TestSortKeysInterfaceWithNonNilElem(t *testing.T) {
 	// Test interface case where IsNil() is false and has non-nil elem
 	// This covers the reflect.Interface case lines 61-65
-	
+
 	// Create a struct that will be passed as interface{}
 	type testStruct struct {
 		Value string
 	}
-	
+
 	testData := map[string]interface{}{
 		"z_key": func() interface{} {
 			// Return a non-nil interface containing a non-nil value
@@ -727,22 +727,22 @@ func TestSortKeysInterfaceWithNonNilElem(t *testing.T) {
 			return iface
 		}(),
 	}
-	
+
 	// This should recursively handle the interface types
 	result := sortKeys(testData)
-	
+
 	// Verify it's JSON-serializable
 	jsonBytes, err := json.Marshal(result)
 	if err != nil {
 		t.Errorf("Failed to marshal result: %v", err)
 	}
-	
+
 	// Verify the keys are sorted
 	var resultMap map[string]interface{}
 	if err := json.Unmarshal(jsonBytes, &resultMap); err != nil {
 		t.Errorf("Failed to unmarshal result: %v", err)
 	}
-	
+
 	// Keys should be in sorted order in the JSON
 	if !strings.Contains(string(jsonBytes), `"a_key"`) {
 		t.Error("Expected a_key in result")
@@ -752,31 +752,31 @@ func TestSortKeysWithJSONNull(t *testing.T) {
 	// Test that unmarshaled JSON with null value triggers the reflect.Interface case
 	// When JSON is unmarshaled, null becomes interface{} with nil value
 	jsonData := `null`
-	
+
 	var data interface{}
 	if err := json.Unmarshal([]byte(jsonData), &data); err != nil {
 		t.Fatalf("Failed to unmarshal JSON: %v", err)
 	}
-	
+
 	// data should be nil after unmarshaling "null"
 	if data != nil {
 		t.Errorf("Expected nil after unmarshaling null, got: %v", data)
 	}
-	
+
 	// sortKeys should handle the null value (which is interface{} containing nil)
 	result := sortKeys(data)
-	
+
 	// Result should be nil
 	if result != nil {
 		t.Errorf("Expected nil result, got: %v", result)
 	}
-	
+
 	// Marshal back to JSON
 	resultJSON, err := MarshalDeterministic(result)
 	if err != nil {
 		t.Fatalf("Failed to marshal result: %v", err)
 	}
-	
+
 	// Verify null is preserved
 	expected := `null`
 	if string(resultJSON) != expected {
@@ -787,7 +787,7 @@ func TestSortKeysWithJSONNull(t *testing.T) {
 func TestSortKeysInterfaceNonNilWithValue(t *testing.T) {
 	// Test the reflect.Interface case where IsNil() is false and contains a value
 	// This specifically tests the return sortKeys(v.Elem().Interface()) path
-	
+
 	// Create data with interface{} values wrapping different types
 	jsonData := `{
 		"z_string": "last",
@@ -798,22 +798,22 @@ func TestSortKeysInterfaceNonNilWithValue(t *testing.T) {
 			"a_nested": null
 		}
 	}`
-	
+
 	var data interface{}
 	if err := json.Unmarshal([]byte(jsonData), &data); err != nil {
 		t.Fatalf("Failed to unmarshal JSON: %v", err)
 	}
-	
+
 	// When unmarshaling, the values in the map are interface{} wrapping concrete types
 	// sortKeys needs to recursively handle these interfaces
 	result := sortKeys(data)
-	
+
 	// Marshal back to JSON
 	resultJSON, err := MarshalDeterministic(result)
 	if err != nil {
 		t.Fatalf("Failed to marshal result: %v", err)
 	}
-	
+
 	// Verify keys are sorted and values are preserved, including nested null
 	expected := `{"a_number":42,"m_bool":true,"nested":{"a_nested":null,"z_nested":"value"},"z_string":"last"}`
 	if string(resultJSON) != expected {

--- a/pkg/jsonschema/errors.go
+++ b/pkg/jsonschema/errors.go
@@ -21,11 +21,11 @@ type ValidationErrorDetail struct {
 
 // ErrorContext holds data available for error message templating
 type ErrorContext struct {
-	SchemaFile   string                  `json:"schemaFile"`   // Path to the schema file
-	Document     string                  `json:"document"`     // The document content (truncated if too long)
-	Errors       []ValidationErrorDetail `json:"errors"`       // Individual validation errors with details
-	ErrorCount   int                     `json:"errorCount"`   // Number of individual errors
-	FullMessage  string                  `json:"fullMessage"`  // Complete formatted error message from jsonschema
+	SchemaFile  string                  `json:"schemaFile"`  // Path to the schema file
+	Document    string                  `json:"document"`    // The document content (truncated if too long)
+	Errors      []ValidationErrorDetail `json:"errors"`      // Individual validation errors with details
+	ErrorCount  int                     `json:"errorCount"`  // Number of individual errors
+	FullMessage string                  `json:"fullMessage"` // Complete formatted error message from jsonschema
 }
 
 // FormatValidationError creates a formatted error message using the provided template
@@ -36,7 +36,7 @@ func FormatValidationError(err error, schemaPath, document, errorTemplate string
 
 	var errors []ValidationErrorDetail
 	var fullMessage string
-	
+
 	if validationErr, ok := err.(*jsonschema.ValidationError); ok {
 		// Parse the document to extract actual values for errors
 		var documentData interface{}
@@ -46,7 +46,7 @@ func FormatValidationError(err error, schemaPath, document, errorTemplate string
 				documentData = data
 			}
 		}
-		
+
 		errors = extractValidationErrors(validationErr, documentData)
 		// Generate full message using sorted errors for consistency
 		fullMessage = generateSortedFullMessage(validationErr, errors)
@@ -72,7 +72,7 @@ func FormatValidationError(err error, schemaPath, document, errorTemplate string
 	tmpl := template.New("error").Funcs(template.FuncMap{
 		"add": func(a, b int) int { return a + b },
 	})
-	
+
 	parsed, err := tmpl.Parse(errorTemplate)
 	if err != nil {
 		return fmt.Errorf("template parsing failed: %v", err)
@@ -106,24 +106,24 @@ func GetCommonTemplate(name string) (string, bool) {
 func generateSortedFullMessage(err *jsonschema.ValidationError, sortedErrors []ValidationErrorDetail) string {
 	// Use the main error prefix from the original error
 	prefix := fmt.Sprintf("jsonschema validation failed with '%s'", err.SchemaURL)
-	
+
 	// Build the error list using our sorted errors
 	var errorLines []string
 	for _, detail := range sortedErrors {
 		// Extract just the validation message part (remove path if present)
 		message := extractCleanMessage(detail.Message, detail.DocumentPath)
-		
+
 		// Use path as-is - per RFC 6901, "" (empty string) is root, not "/"
 		displayPath := detail.DocumentPath
-		
+
 		errorLine := fmt.Sprintf("- at '%s': %s", displayPath, message)
 		errorLines = append(errorLines, errorLine)
 	}
-	
+
 	if len(errorLines) > 0 {
 		return prefix + "\n" + strings.Join(errorLines, "\n")
 	}
-	
+
 	return prefix
 }
 
@@ -132,11 +132,11 @@ func extractCleanMessage(message, path string) string {
 	// Per RFC 6901, root path is "" (empty string), not "/"
 	// Error messages from the library will use this format: "at '<path>': <message>"
 	expectedPrefix := fmt.Sprintf("at '%s': ", path)
-	
+
 	if strings.HasPrefix(message, expectedPrefix) {
 		return message[len(expectedPrefix):]
 	}
-	
+
 	// If no path prefix found, return message as-is
 	return message
 }
@@ -144,7 +144,7 @@ func extractCleanMessage(message, path string) string {
 // extractValidationErrors recursively extracts all validation errors from the error tree
 func extractValidationErrors(err *jsonschema.ValidationError, documentData interface{}) []ValidationErrorDetail {
 	var errors []ValidationErrorDetail
-	
+
 	// If there are child causes, extract them individually (they contain the specific errors)
 	if len(err.Causes) > 0 {
 		for _, child := range err.Causes {
@@ -154,7 +154,7 @@ func extractValidationErrors(err *jsonschema.ValidationError, documentData inter
 		sortValidationErrors(errors)
 		return errors
 	}
-	
+
 	// If no child causes, this is a leaf error - use it directly
 	detail := ValidationErrorDetail{
 		Message:      err.Error(),
@@ -162,7 +162,7 @@ func extractValidationErrors(err *jsonschema.ValidationError, documentData inter
 		SchemaPath:   err.SchemaURL,
 		Value:        extractValueAtPath(documentData, err.InstanceLocation),
 	}
-	
+
 	errors = append(errors, detail)
 	return errors
 }
@@ -180,7 +180,7 @@ func extractValueAtPath(data interface{}, path []string) string {
 		}
 		return ""
 	}
-	
+
 	// Navigate to the value at the path
 	current := data
 	for _, key := range path {
@@ -203,18 +203,18 @@ func extractValueAtPath(data interface{}, path []string) string {
 			return "" // Can't navigate further
 		}
 	}
-	
+
 	// Serialize the value to JSON
 	if jsonBytes, err := json.Marshal(current); err == nil {
 		return string(jsonBytes)
 	}
-	
+
 	return ""
 }
 
 // sortValidationErrors sorts validation errors for consistent ordering
 // Primary sort: by DocumentPath (field name)
-// Secondary sort: by Message (for same field, different constraint violations)  
+// Secondary sort: by Message (for same field, different constraint violations)
 func sortValidationErrors(errors []ValidationErrorDetail) {
 	sort.Slice(errors, func(i, j int) bool {
 		// First, sort by path
@@ -233,15 +233,13 @@ func formatInstanceLocation(location []string) string {
 	if len(location) == 0 {
 		return "" // Empty string for root, per RFC 6901
 	}
-	
+
 	// Build JSON Pointer: "/" + each reference token
 	// Note: RFC 6901 requires escaping "~" as "~0" and "/" as "~1" in tokens
 	// The jsonschema library should provide already-decoded tokens
 	var pathParts []string
-	for _, part := range location {
-		pathParts = append(pathParts, part)
-	}
-	
+	pathParts = append(pathParts, location...)
+
 	return "/" + strings.Join(pathParts, "/")
 }
 

--- a/pkg/jsonschema/errors_test.go
+++ b/pkg/jsonschema/errors_test.go
@@ -5,13 +5,13 @@ import (
 	"fmt"
 	"strings"
 	"testing"
-	
+
 	"github.com/santhosh-tekuri/jsonschema/v6"
 )
 
 func TestErrorMessageTemplating(t *testing.T) {
 	mockError := fmt.Errorf("required property 'name' missing")
-	
+
 	testCases := []struct {
 		name     string
 		template string
@@ -71,8 +71,12 @@ func TestErrorFormattingEdgeCases(t *testing.T) {
 	}
 
 	// Test all available variables
-	result3 := FormatValidationError(mockError, "test.schema.json", `{"test": true}`, 
-		"Error: {{.FullMessage}}, Schema: {{.SchemaFile}}, Count: {{.ErrorCount}}, Doc: {{.Document}}")
+	result3 := FormatValidationError(
+		mockError,
+		"test.schema.json",
+		`{"test": true}`,
+		"Error: {{.FullMessage}}, Schema: {{.SchemaFile}}, Count: {{.ErrorCount}}, Doc: {{.Document}}",
+	)
 	expected := `Error: validation error, Schema: test.schema.json, Count: 1, Doc: {"test": true}`
 	if result3.Error() != expected {
 		t.Errorf("Expected: %s\nGot: %s", expected, result3.Error())
@@ -105,38 +109,43 @@ func TestFormatValidationErrorComplexScenarios(t *testing.T) {
 			schemaPath: "/path/to/schema.json",
 			document:   `{"name": 123}`,
 			template:   "Error: {{.FullMessage}} | Schema: {{.SchemaFile}}",
-			expectedContains: []string{"Error:", "validation failed", "Schema:", "/path/to/schema.json"},
+			expectedContains: []string{
+				"Error:",
+				"validation failed",
+				"Schema:",
+				"/path/to/schema.json",
+			},
 		},
 		{
-			name:       "Template with error count",
-			err:        &MockValidationError{message: "type error", path: "/age"},
-			schemaPath: "user.schema.json",
-			document:   `{"age": "twenty"}`,
-			template:   "Found {{.ErrorCount}} error(s) in schema {{.SchemaFile}}: {{range .Errors}}{{.Message}}{{end}}",
+			name:             "Template with error count",
+			err:              &MockValidationError{message: "type error", path: "/age"},
+			schemaPath:       "user.schema.json",
+			document:         `{"age": "twenty"}`,
+			template:         "Found {{.ErrorCount}} error(s) in schema {{.SchemaFile}}: {{range .Errors}}{{.Message}}{{end}}",
 			expectedContains: []string{"Found 1 error(s)", "user.schema.json", "type error"},
 		},
 		{
-			name:       "Template with path iteration",
-			err:        &MockValidationError{message: "missing field"},
-			schemaPath: "schema.json",
-			document:   "{}",
-			template:   "{{range .Errors}}Path {{.DocumentPath}}: {{.Message}}{{end}}",
+			name:             "Template with path iteration",
+			err:              &MockValidationError{message: "missing field"},
+			schemaPath:       "schema.json",
+			document:         "{}",
+			template:         "{{range .Errors}}Path {{.DocumentPath}}: {{.Message}}{{end}}",
 			expectedContains: []string{"Path :", "missing field"},
 		},
 		{
-			name:       "Invalid Go template syntax",
-			err:        &MockValidationError{message: "test error"},
-			schemaPath: "test.json",
-			document:   "{}",
-			template:   "{{.Errors", // Missing closing braces
+			name:             "Invalid Go template syntax",
+			err:              &MockValidationError{message: "test error"},
+			schemaPath:       "test.json",
+			document:         "{}",
+			template:         "{{.Errors", // Missing closing braces
 			expectedContains: []string{"template parsing failed"},
 		},
 		{
-			name:       "Non-validation error",
-			err:        fmt.Errorf("generic error"),
-			schemaPath: "test.json",
-			document:   "{}",
-			template:   "Custom: {{.FullMessage}}",
+			name:             "Non-validation error",
+			err:              fmt.Errorf("generic error"),
+			schemaPath:       "test.json",
+			document:         "{}",
+			template:         "Custom: {{.FullMessage}}",
 			expectedContains: []string{"Custom:", "generic error"},
 		},
 	}
@@ -153,7 +162,11 @@ func TestFormatValidationErrorComplexScenarios(t *testing.T) {
 			errorMessage := result.Error()
 			for _, expected := range tt.expectedContains {
 				if !strings.Contains(errorMessage, expected) {
-					t.Errorf("expected error message to contain %q, got: %s", expected, errorMessage)
+					t.Errorf(
+						"expected error message to contain %q, got: %s",
+						expected,
+						errorMessage,
+					)
 				}
 			}
 		})
@@ -176,57 +189,57 @@ func TestNilErrorHandling(t *testing.T) {
 
 func TestGetCommonTemplate(t *testing.T) {
 	tests := []struct {
-		name       string
-		templateName string
-		expectFound bool
+		name             string
+		templateName     string
+		expectFound      bool
 		expectedTemplate string
 	}{
 		{
-			name:         "simple template",
-			templateName: "simple",
-			expectFound:  true,
+			name:             "simple template",
+			templateName:     "simple",
+			expectFound:      true,
 			expectedTemplate: "{{.FullMessage}}",
 		},
 		{
-			name:         "basic template",
-			templateName: "basic",
-			expectFound:  true,
+			name:             "basic template",
+			templateName:     "basic",
+			expectFound:      true,
 			expectedTemplate: "{{range .Errors}}{{.Message}}\n{{end}}",
 		},
 		{
-			name:         "detailed template",
-			templateName: "detailed",
-			expectFound:  true,
+			name:             "detailed template",
+			templateName:     "detailed",
+			expectFound:      true,
 			expectedTemplate: "{{.ErrorCount}} validation error(s) found:\n{{range $i, $e := .Errors}}{{add $i 1}}. {{.Message}} at {{.DocumentPath}}\n{{end}}",
 		},
 		{
-			name:         "with_path template",
-			templateName: "with_path",
-			expectFound:  true,
+			name:             "with_path template",
+			templateName:     "with_path",
+			expectFound:      true,
 			expectedTemplate: "{{range .Errors}}{{.DocumentPath}}: {{.Message}}\n{{end}}",
 		},
 		{
-			name:         "with_schema template",
-			templateName: "with_schema",
-			expectFound:  true,
+			name:             "with_schema template",
+			templateName:     "with_schema",
+			expectFound:      true,
 			expectedTemplate: "Schema {{.SchemaFile}} validation failed:\n{{.FullMessage}}",
 		},
 		{
-			name:         "verbose template",
-			templateName: "verbose",
-			expectFound:  true,
+			name:             "verbose template",
+			templateName:     "verbose",
+			expectFound:      true,
 			expectedTemplate: "Validation Results:\nSchema: {{.SchemaFile}}\nErrors: {{.ErrorCount}}\nFull Message: {{.FullMessage}}\n\nIndividual Errors:\n{{range $i, $e := .Errors}}Error {{add $i 1}}:\n  Document Path: {{.DocumentPath}}\n  Schema Path: {{.SchemaPath}}\n  Message: {{.Message}}{{if .Value}}\n  Value: {{.Value}}{{end}}\n\n{{end}}",
 		},
 		{
-			name:         "non-existent template",
-			templateName: "nonexistent",
-			expectFound:  false,
+			name:             "non-existent template",
+			templateName:     "nonexistent",
+			expectFound:      false,
 			expectedTemplate: "",
 		},
 		{
-			name:         "empty template name",
-			templateName: "",
-			expectFound:  false,
+			name:             "empty template name",
+			templateName:     "",
+			expectFound:      false,
 			expectedTemplate: "",
 		},
 	}
@@ -234,13 +247,17 @@ func TestGetCommonTemplate(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			template, found := GetCommonTemplate(tt.templateName)
-			
+
 			if found != tt.expectFound {
 				t.Errorf("GetCommonTemplate() found = %v, expectFound = %v", found, tt.expectFound)
 			}
-			
+
 			if found && template != tt.expectedTemplate {
-				t.Errorf("GetCommonTemplate() template = %v, expectedTemplate = %v", template, tt.expectedTemplate)
+				t.Errorf(
+					"GetCommonTemplate() template = %v, expectedTemplate = %v",
+					template,
+					tt.expectedTemplate,
+				)
 			}
 		})
 	}
@@ -250,14 +267,14 @@ func TestValidationErrorSorting(t *testing.T) {
 	// Test that validation errors are consistently ordered
 	unsortedErrors := []ValidationErrorDetail{
 		{Message: "error at /z", DocumentPath: "/z"},
-		{Message: "error at /a", DocumentPath: "/a"},  
+		{Message: "error at /a", DocumentPath: "/a"},
 		{Message: "second error at /a", DocumentPath: "/a"},
 		{Message: "error at /b", DocumentPath: "/b"},
 	}
-	
+
 	// Sort using our function
 	sortValidationErrors(unsortedErrors)
-	
+
 	// Verify the order
 	expected := []ValidationErrorDetail{
 		{Message: "error at /a", DocumentPath: "/a"},
@@ -265,7 +282,7 @@ func TestValidationErrorSorting(t *testing.T) {
 		{Message: "error at /b", DocumentPath: "/b"},
 		{Message: "error at /z", DocumentPath: "/z"},
 	}
-	
+
 	for i, err := range unsortedErrors {
 		if err.DocumentPath != expected[i].DocumentPath || err.Message != expected[i].Message {
 			t.Errorf("Expected error %d to be %+v, got %+v", i, expected[i], err)
@@ -275,8 +292,15 @@ func TestValidationErrorSorting(t *testing.T) {
 
 func TestCommonErrorTemplatesExist(t *testing.T) {
 	// Test that all expected common templates exist
-	expectedTemplates := []string{"basic", "detailed", "simple", "with_path", "with_schema", "verbose"}
-	
+	expectedTemplates := []string{
+		"basic",
+		"detailed",
+		"simple",
+		"with_path",
+		"with_schema",
+		"verbose",
+	}
+
 	for _, templateName := range expectedTemplates {
 		t.Run("template_"+templateName, func(t *testing.T) {
 			template, found := GetCommonTemplate(templateName)
@@ -483,9 +507,9 @@ func TestGenerateSortedFullMessage(t *testing.T) {
 		expectedParts []string
 	}{
 		{
-			name:     "error with multiple parts",
-			errorMsg: "validation error",
-			template: "{{.FullMessage}}",
+			name:          "error with multiple parts",
+			errorMsg:      "validation error",
+			template:      "{{.FullMessage}}",
 			expectedParts: []string{"validation error"},
 		},
 	}
@@ -493,8 +517,13 @@ func TestGenerateSortedFullMessage(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mockErr := fmt.Errorf("%s", tt.errorMsg)
-			result := FormatValidationError(mockErr, "test.schema.json", `{"test": "data"}`, tt.template)
-			
+			result := FormatValidationError(
+				mockErr,
+				"test.schema.json",
+				`{"test": "data"}`,
+				tt.template,
+			)
+
 			for _, part := range tt.expectedParts {
 				if !strings.Contains(result.Error(), part) {
 					t.Errorf("Expected result to contain %q, got %q", part, result.Error())
@@ -511,9 +540,9 @@ func TestSortValidationErrorsSecondarySort(t *testing.T) {
 		{Message: "error a", DocumentPath: "/same"},
 		{Message: "error m", DocumentPath: "/same"},
 	}
-	
+
 	sortValidationErrors(errors)
-	
+
 	// Verify they are sorted alphabetically by message
 	if errors[0].Message != "error a" {
 		t.Errorf("Expected first error to be 'error a', got %q", errors[0].Message)
@@ -530,14 +559,14 @@ func TestFormatValidationErrorWithLongDocument(t *testing.T) {
 	// Test document truncation in error context
 	longDocument := strings.Repeat("x", 1000)
 	mockErr := fmt.Errorf("validation error")
-	
+
 	result := FormatValidationError(mockErr, "test.json", longDocument, "Doc: {{.Document}}")
-	
+
 	// Verify the document was truncated
 	if !strings.Contains(result.Error(), "...") {
 		t.Error("Expected document to be truncated in error message")
 	}
-	
+
 	// Verify error message is not absurdly long
 	if len(result.Error()) > 600 {
 		t.Errorf("Error message too long: %d characters", len(result.Error()))
@@ -547,10 +576,10 @@ func TestFormatValidationErrorWithLongDocument(t *testing.T) {
 func TestFormatValidationErrorTemplateAddFunction(t *testing.T) {
 	// Test the template's add function
 	mockErr := fmt.Errorf("validation error")
-	
-	result := FormatValidationError(mockErr, "test.json", `{"test": "data"}`, 
+
+	result := FormatValidationError(mockErr, "test.json", `{"test": "data"}`,
 		"Error {{add 1 2}}: {{.FullMessage}}")
-	
+
 	if !strings.Contains(result.Error(), "Error 3:") {
 		t.Errorf("Expected add function to work, got: %s", result.Error())
 	}
@@ -559,7 +588,7 @@ func TestFormatValidationErrorTemplateAddFunction(t *testing.T) {
 func TestFormatValidationErrorEdgeCaseTemplates(t *testing.T) {
 	// Test various template edge cases
 	mockErr := fmt.Errorf("test error")
-	
+
 	tests := []struct {
 		name     string
 		template string
@@ -581,7 +610,7 @@ func TestFormatValidationErrorEdgeCaseTemplates(t *testing.T) {
 			expected: "Has errors",
 		},
 	}
-	
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := FormatValidationError(mockErr, "test.json", `{}`, tt.template)
@@ -804,7 +833,7 @@ func TestExtractValueAtPath(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := extractValueAtPath(tt.data, tt.path)
-			
+
 			if tt.expected == "" && result != "" {
 				// Check if it's a truncation case
 				if !strings.Contains(result, "...") {
@@ -923,52 +952,52 @@ func TestValueFieldPopulationIntegration(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// Load schema
 			compiler := jsonschema.NewCompiler()
-			
+
 			// Parse schema
 			var schemaData interface{}
 			if err := json.Unmarshal([]byte(tt.schema), &schemaData); err != nil {
 				t.Fatalf("Failed to parse schema: %v", err)
 			}
-			
+
 			if err := compiler.AddResource("test.schema.json", schemaData); err != nil {
 				t.Fatalf("Failed to add schema: %v", err)
 			}
-			
+
 			schema, err := compiler.Compile("test.schema.json")
 			if err != nil {
 				t.Fatalf("Failed to compile schema: %v", err)
 			}
-			
+
 			// Parse document
 			var doc interface{}
 			if err := json.Unmarshal([]byte(tt.document), &doc); err != nil {
 				t.Fatalf("Failed to parse document: %v", err)
 			}
-			
+
 			// Validate
 			err = schema.Validate(doc)
 			if err == nil {
 				t.Fatal("Expected validation error, got none")
 			}
-			
+
 			// Type assert to ValidationError
 			validationErr, ok := err.(*jsonschema.ValidationError)
 			if !ok {
 				t.Fatalf("Expected *jsonschema.ValidationError, got %T", err)
 			}
-			
+
 			// Extract errors
 			errors := extractValidationErrors(validationErr, doc)
-			
+
 			// Verify Value field is populated correctly
 			for _, valErr := range errors {
 				expectedValue, exists := tt.expectedValues[valErr.DocumentPath]
 				if !exists {
 					continue // Not checking this error
 				}
-				
+
 				if valErr.Value != expectedValue {
-					t.Errorf("Path %s: expected value %q, got %q", 
+					t.Errorf("Path %s: expected value %q, got %q",
 						valErr.DocumentPath, expectedValue, valErr.Value)
 				}
 			}

--- a/pkg/jsonschema/json5.go
+++ b/pkg/jsonschema/json5.go
@@ -28,7 +28,7 @@ func JSON5ToJSON(content []byte) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	
+
 	return MarshalDeterministic(data)
 }
 
@@ -48,13 +48,13 @@ func (l JSON5FileLoader) Load(url string) (interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	
+
 	// Read and parse the file as JSON5
 	content, err := os.ReadFile(filePath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read file %q: %w", filePath, err)
 	}
-	
+
 	// Use our existing JSON5 parsing function
 	return ParseJSON5(content)
 }

--- a/pkg/jsonschema/json5_test.go
+++ b/pkg/jsonschema/json5_test.go
@@ -92,7 +92,7 @@ func TestParseJSON5String(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result, err := ParseJSON5String(tt.input)
-			
+
 			if tt.expectError {
 				if err == nil {
 					t.Errorf("expected error but got none")
@@ -172,7 +172,7 @@ func TestJSON5StringToJSON(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result, err := JSON5StringToJSON(tt.input)
-			
+
 			if tt.expectError {
 				if err == nil {
 					t.Errorf("expected error but got none")
@@ -216,7 +216,7 @@ func TestJSON5ToJSON(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result, err := JSON5ToJSON(tt.input)
-			
+
 			if tt.expectError {
 				if err == nil {
 					t.Errorf("expected error but got none")
@@ -240,7 +240,7 @@ func TestJSON5FileLoader(t *testing.T) {
 	// Create a temporary JSON5 file
 	tmpDir := t.TempDir()
 	json5File := filepath.Join(tmpDir, "test.json5")
-	
+
 	json5Content := `{
 		// JSON5 test file with comments
 		"name": "test",
@@ -249,30 +249,30 @@ func TestJSON5FileLoader(t *testing.T) {
 			"enabled": true
 		}
 	}`
-	
+
 	if err := os.WriteFile(json5File, []byte(json5Content), 0644); err != nil {
 		t.Fatalf("Failed to write test file: %v", err)
 	}
-	
+
 	// Test loading with JSON5FileLoader
 	loader := JSON5FileLoader{}
 	fileURL := fmt.Sprintf("file://%s", json5File)
-	
+
 	data, err := loader.Load(fileURL)
 	if err != nil {
 		t.Fatalf("Failed to load JSON5 file: %v", err)
 	}
-	
+
 	// Verify the loaded data
 	dataMap, ok := data.(map[string]interface{})
 	if !ok {
 		t.Fatalf("Expected map[string]interface{}, got %T", data)
 	}
-	
+
 	if dataMap["name"] != "test" {
 		t.Errorf("Expected name='test', got %v", dataMap["name"])
 	}
-	
+
 	if configMap, ok := dataMap["config"].(map[string]interface{}); !ok {
 		t.Errorf("Expected config to be map, got %T", dataMap["config"])
 	} else if configMap["enabled"] != true {
@@ -282,7 +282,7 @@ func TestJSON5FileLoader(t *testing.T) {
 
 func TestJSON5FileLoaderErrors(t *testing.T) {
 	loader := JSON5FileLoader{}
-	
+
 	t.Run("invalid URL scheme", func(t *testing.T) {
 		// Test with non-file URL that ToFile can't handle
 		_, err := loader.Load("http://example.com/schema.json")
@@ -290,7 +290,7 @@ func TestJSON5FileLoaderErrors(t *testing.T) {
 			t.Error("Expected error for non-file URL, got nil")
 		}
 	})
-	
+
 	t.Run("missing file", func(t *testing.T) {
 		// Test with valid file URL but missing file
 		missingFile := "file:///tmp/nonexistent_file_12345.json"
@@ -306,16 +306,16 @@ func TestJSON5FileLoaderErrors(t *testing.T) {
 			}
 		}
 	})
-	
+
 	t.Run("invalid JSON5 content", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		invalidFile := filepath.Join(tmpDir, "invalid.json5")
-		
+
 		// Write invalid JSON5 content
 		if err := os.WriteFile(invalidFile, []byte(`{invalid json`), 0644); err != nil {
 			t.Fatalf("Failed to write test file: %v", err)
 		}
-		
+
 		fileURL := fmt.Sprintf("file://%s", invalidFile)
 		_, err := loader.Load(fileURL)
 		if err == nil {
@@ -402,7 +402,7 @@ func TestParseJSON5EdgeCases(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result, err := ParseJSON5(tt.input)
-			
+
 			if tt.expectError {
 				if err == nil {
 					t.Errorf("%s: expected error but got none", tt.description)
@@ -421,10 +421,10 @@ func TestParseJSON5EdgeCases(t *testing.T) {
 
 func TestJSON5ToJSONEdgeCases(t *testing.T) {
 	tests := []struct {
-		name          string
-		input         []byte
-		expectError   bool
-		validateJSON  bool
+		name         string
+		input        []byte
+		expectError  bool
+		validateJSON bool
 	}{
 		{
 			name:         "complex nested structure",
@@ -454,7 +454,7 @@ func TestJSON5ToJSONEdgeCases(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result, err := JSON5ToJSON(tt.input)
-			
+
 			if tt.expectError {
 				if err == nil {
 					t.Error("expected error but got none")
@@ -480,7 +480,7 @@ func TestJSON5ToJSONEdgeCases(t *testing.T) {
 
 func TestJSON5FileLoaderWithVariousFormats(t *testing.T) {
 	tmpDir := t.TempDir()
-	
+
 	tests := []struct {
 		name        string
 		content     string


### PR DESCRIPTION
Add comprehensive linting and formatting checks before build:
- go fmt verification to ensure consistent code formatting
- go vet for detecting suspicious constructs
- golangci-lint with multiple linters (errcheck, gosimple, govet, staticcheck, etc.)

Add .golangci.yml configuration with sensible defaults:
- Enable standard Go quality tools
- Import formatting with goimports
- Code quality checks (goconst, gocyclo, dupl, gocritic)
- Spelling checks with misspell
- Relaxed rules for test files

The lint job now runs before build, ensuring code quality standards are met before proceeding with tests and builds.

Thanks to @binlab for highlighting the need for proper code quality gates in the CI pipeline!